### PR TITLE
fix(javascript): fix ToC links on JS overview page

### DIFF
--- a/content/javascript/index.md
+++ b/content/javascript/index.md
@@ -1,18 +1,18 @@
 ---
-title: Javascript
+title: Javascript Development Standards
 date: "2021-04-01T23:46:37.121Z"
 area: Javascript
 section: 1. Overview
 description: ""
 ---
 
-#Javascript Development Standards
 This document is largely based on Douglas Crockford's [Code Conventions for JavaScript](http://javascript.crockford.com/code.html). Changes have been made where necessary to merge it with the standards typically used in jQuery code. When changes were not necessary, Douglas Crockford's own words were left untouched.
 
-All of our JavaScript code is sent directly to the public. It should always be of publication quality. Neatness counts. 
+All of our JavaScript code is sent directly to the public. It should always be of publication quality. Neatness counts.
 
-##Table of Contents
+## Table of Contents
 
-  1. [General Authoring](/javascript/general/)
-  1. [jQuery Best Practices](/javascript/jquery/)
+  1. [Authoring Guidelines](/javascript/general-authoring/)
+  1. [Large Application Development Standards](/javascript/large-applications/)
   1. [Resources](/javascript/resources/)
+  1. [jQuery](/javascript/jquery-best-practices/)


### PR DESCRIPTION
### What changed
- Fixed links for the JS ToC
- Removed duplicate title
- Renamed link labels to match page titles

### How to test
- Run `npm start`
- Go to http://localhost:8000/javascript/
- Click each of the links in the table of contents