### PR TITLE
Content: Missing word on Performance Page

### DIFF
--- a/content/performance/index.md
+++ b/content/performance/index.md
@@ -108,7 +108,7 @@ Do not use too many fonts on your site, and do not import more font variants tha
 The WOFF format is pre-compressed and works in all modern browsers and is the preferred format. WOFF2 comes with the best compression out of the box, but has less browser support. If you need to use TTF or EOT formats (TTF for old Android browsers, EOT for IE), be sure to compressing the font files with GZIP when delivering the fonts.
 
 ### Include local() & format() Directives in a @font-face Declaration
-When you the `local()` directive in a `@font-face` declaration, the browser will first check for the font locally. If the font exists locally, it will stop and render the font from the local resource. When you use the `format()` directive, the browser will only download a resource if the browser supports that format. 
+When you use the `local()` directive in a `@font-face` declaration, the browser will first check for the font locally. If the font exists locally, it will stop and render the font from the local resource. When you use the `format()` directive, the browser will only download a resource if the browser supports that format. 
 
 Your declaration should look something like this:
 


### PR DESCRIPTION
## Changes

- Summarize the changes made in this pull request

On the performance page, under the "Include local() & format()..." heading, there was a missing word in the first sentence. Added the word "use" to the sentence.

Issue Screenshot:
![image](https://github.com/thinkcompany/think_dev-standards/assets/42557377/14ef7431-827c-4dfd-b087-982391ab9973)

## Checklist
Check all the boxes that apply to this pull request
- [x] Spelling and Formatting have been checked
- [ ] Example code has been included where needed
- [ ] References and links are included where needed
- [ ] This pull request requires an update to dependencies
- [ ] This change looks good on mobile

## How To Review
Describe how the reviewer can see these changes, either by running the code locally on their own machine or viewing it in a published environment.

## Tickets Closed
List tickets closed by this pull request

- Closes [THINKDOCS-##](#link#)