### PR TITLE
Add AI agent instruction files (Claude, Cursor, Copilot)

### DIFF
--- a/.cursor/rules/think-standards.mdc
+++ b/.cursor/rules/think-standards.mdc
@@ -1,0 +1,21 @@
+---
+description: Think Company coding standards — applies to all files in this project
+globs: ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.scss", "**/*.css", "**/*.html"]
+alwaysApply: true
+---
+
+# Think Company Coding Standards
+
+Follow all standards in `AGENTS.md` at the repo root.
+
+## Key rules for Cursor
+
+- TypeScript only. `strict: true`. Never use `any`.
+- Functional React components only. Hooks for state and effects.
+- WCAG 2.2 AA accessibility on all UI.
+- Conventional Commits format for commit messages.
+- No inline styles, no inline event handlers.
+- Sass with `@use`/`@forward` — not `@import`.
+- One component per file, PascalCase filename matches component name.
+
+See `AGENTS.md` for the full standard.

--- a/.cursor/rules/think-standards.mdc
+++ b/.cursor/rules/think-standards.mdc
@@ -10,12 +10,14 @@ Follow all standards in `AGENTS.md` at the repo root.
 
 ## Key rules for Cursor
 
-- TypeScript only. `strict: true`. Never use `any`.
-- Functional React components only. Hooks for state and effects.
-- WCAG 2.2 AA accessibility on all UI.
+- TypeScript only. `strict: true`. Never use `any` — use `unknown` and narrow. Validate external data with Zod/Valibot, not an `as` cast.
+- `const` by default, never `var`. Modern operators (`?.`, `??`, logical assignment). `async`/`await` over promise chains. `for...of`/`Object.entries`, never `for...in`.
+- Functional React components only. Hooks for state and effects. `useEffect` synchronizes with external systems — don't derive state in it; declare all deps; return cleanup.
+- Server state → TanStack Query/SWR (not Redux). Reusable logic → custom hooks. Wrap failure-prone subtrees in an error boundary.
+- WCAG 2.2 AA accessibility on all UI. `:focus-visible` focus states, targets ≥ 24×24px, respect `prefers-reduced-motion`. Native `required` over `aria-required`.
+- Vanilla CSS is the default; Tailwind as a utility layer where agreed. Sass is grandfathered, not for new work. Custom-property tokens; modern CSS (cascade layers, container queries, `:has()`, logical properties).
 - Conventional Commits format for commit messages.
-- No inline styles, no inline event handlers.
-- Sass with `@use`/`@forward` — not `@import`.
+- No inline styles, no inline event handlers. No secrets in code.
 - One component per file, PascalCase filename matches component name.
 
 See `AGENTS.md` for the full standard.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,35 @@
+# Think Company — GitHub Copilot Instructions
+
+Follow the standards in `AGENTS.md` at the repo root. The rules below are a summary for Copilot's inline suggestion context.
+
+## TypeScript
+- Strict mode. No `any`. Use `unknown` and narrow explicitly.
+- `interface` for extendable object shapes; `type` for unions and aliases.
+- Use utility types (`Partial`, `Pick`, `Omit`, `ReturnType`, etc.) — do not reimplement them.
+- Avoid `as` assertions and `!` non-null assertions without an explanatory comment.
+
+## React
+- Functional components only. Hooks for state and effects.
+- One component per `.tsx` file. Filename = component name (PascalCase).
+- No array index as `key`. No spreading unknown props onto DOM elements.
+- Conditional rendering: no nested ternaries — break into components.
+
+## CSS / Sass
+- SCSS syntax. `@use`/`@forward` only (not `@import`).
+- No vendor prefixes in source — use Autoprefixer.
+- No `!important`. No ID selectors for styling. Max 3 nesting levels.
+- Mobile-first media queries. Unitless `line-height`.
+
+## Accessibility
+- WCAG 2.2 AA. Keyboard-accessible. Visible focus states.
+- Semantic HTML. Logical heading hierarchy. `alt` on every `<img>`.
+- ARIA only when native HTML is insufficient.
+
+## Git
+- Conventional Commits: `feat(scope): message` / `fix(scope): message`.
+- One logical change per commit.
+
+## General
+- No inline styles or inline event handlers.
+- No secrets or credentials in code.
+- Validate input at system boundaries. Follow OWASP Top 10.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,22 +7,36 @@ Follow the standards in `AGENTS.md` at the repo root. The rules below are a summ
 - `interface` for extendable object shapes; `type` for unions and aliases.
 - Use utility types (`Partial`, `Pick`, `Omit`, `ReturnType`, etc.) — do not reimplement them.
 - Avoid `as` assertions and `!` non-null assertions without an explanatory comment.
+- Use `as const` and discriminated unions for state. Validate external data (API, form, storage) at runtime with Zod/Valibot, not an `as` cast.
+
+## JavaScript
+- `const` by default, never `var`. Declare variables near first use.
+- Be explicit in conditions: `if (count > 0)` over `if (count)` — truthy shortcuts hide `0`/`''`/`null` bugs.
+- Modern operators: `?.`, `??` (not `||`) for defaults, logical assignment.
+- `async`/`await` over promise chains; `Promise.all` for independent work.
+- `for...of` and `Object.entries` — never `for...in`. Trailing commas in multiline.
+- `addEventListener` only; `IntersectionObserver`/`ResizeObserver` over scroll/resize polling.
 
 ## React
 - Functional components only. Hooks for state and effects.
 - One component per `.tsx` file. Filename = component name (PascalCase).
 - No array index as `key`. No spreading unknown props onto DOM elements.
-- Conditional rendering: no nested ternaries — break into components.
+- `useEffect` synchronizes with external systems — don't derive state in it; declare all deps; return cleanup.
+- Server state → TanStack Query/SWR (not Redux). URL state → query params. Reusable logic → custom hooks.
+- Wrap failure-prone subtrees in an error boundary. Conditional rendering: no nested ternaries.
 
-## CSS / Sass
-- SCSS syntax. `@use`/`@forward` only (not `@import`).
-- No vendor prefixes in source — use Autoprefixer.
+## CSS
+- Vanilla CSS is the default; Tailwind as a utility layer where agreed. Sass is grandfathered, not for new work.
+- Custom properties for all design tokens. No vendor prefixes in source — use Autoprefixer.
 - No `!important`. No ID selectors for styling. Max 3 nesting levels.
 - Mobile-first media queries. Unitless `line-height`.
+- Modern CSS: cascade layers, container queries, `:has()`, logical properties, `oklch`/`color-mix`.
 
 ## Accessibility
-- WCAG 2.2 AA. Keyboard-accessible. Visible focus states.
+- WCAG 2.2 AA. Keyboard-accessible. Visible focus states via `:focus-visible`.
+- Interactive targets ≥ 24×24px. Respect `prefers-reduced-motion`.
 - Semantic HTML. Logical heading hierarchy. `alt` on every `<img>`.
+- Native `required` is the source of truth for required fields; `aria-required` only on custom widgets.
 - ARIA only when native HTML is insufficient.
 
 ## Git
@@ -31,5 +45,6 @@ Follow the standards in `AGENTS.md` at the repo root. The rules below are a summ
 
 ## General
 - No inline styles or inline event handlers.
-- No secrets or credentials in code.
+- No secrets or credentials in code; run a secret-scanning hook.
 - Validate input at system boundaries. Follow OWASP Top 10.
+- Set a CSP; add SRI to third-party scripts; enforce HTTPS/HSTS; automate dependency scanning.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,186 @@
+# Think Company — AI Agent Coding Instructions
+
+These instructions apply to all AI-assisted coding at Think Company. They encode our front-end development standards and are the authoritative source for the per-tool files (`CLAUDE.md`, `.cursor/rules/`, `.github/copilot-instructions.md`).
+
+---
+
+## Core Principles
+
+- Write code that is readable, modular, and accessible by default.
+- Prefer explicit over clever. Prioritize the next developer's ability to understand and change the code.
+- Follow the conventions already in use in the project. When in doubt, match the surrounding code.
+- Do not add features, abstractions, or error handling beyond what the task requires.
+- Validate at system boundaries (user input, external APIs). Trust internal code.
+
+---
+
+## TypeScript
+
+- All new code must be TypeScript. Do not introduce plain `.js` files.
+- Enable `strict: true` in `tsconfig.json`. Never disable strict mode to work around a type error — fix the type.
+- Never use `any`. Prefer `unknown` when the type is genuinely unknown and narrow it explicitly.
+- Prefer `interface` for object shapes that may be extended; use `type` for unions, intersections, and aliases.
+- Use built-in utility types (`Partial`, `Required`, `Pick`, `Omit`, `Readonly`, `ReturnType`, etc.) rather than re-implementing them.
+- Keep type definitions co-located with the code that uses them. Only promote to a shared `types/` directory when truly shared.
+- Avoid type assertions (`as Foo`) except at verified system boundaries. Never use non-null assertions (`!`) without a comment explaining why the value cannot be null.
+- Prefer `satisfies` over `as` when you need to validate a value against a type without widening it.
+
+---
+
+## JavaScript
+
+- Use `const` by default. Use `let` only when the value will be reassigned. Never use `var`.
+- Use `===` and `!==`. Never `==` or `!=`.
+- Use template literals for string interpolation. No string concatenation.
+- Arrow functions for callbacks and closures. Named function declarations for top-level functions (better stack traces).
+- Never use `eval` or the `Function` constructor.
+- Avoid assignments inside conditionals.
+- Wrap immediately-invoked function expressions in parentheses.
+- Do not bind to scroll or resize events without debouncing.
+
+---
+
+## React
+
+- Use functional components exclusively. Do not write new class components.
+- Use hooks for all state and side effects. Do not use `componentWillMount`, `componentWillReceiveProps`, or other deprecated lifecycle methods.
+- One component per file. Filename and component name must match. Use PascalCase (e.g., `UserCard.tsx`).
+- Always use `.tsx` for files containing JSX.
+- Use double quotes for JSX attributes; single quotes for all other JS/TS strings.
+- Do not use array index as `key` prop. Use a stable, unique ID.
+- Do not spread props onto DOM elements without filtering (`{...rest}` onto a `<div>` leaks unknown attributes).
+- State management:
+  - Single component: `useState`
+  - Component trees (2+ levels): React Context
+  - Application-wide: Redux with Redux Toolkit (RTK)
+- Do not use `isMounted`. It is deprecated and unavailable in functional components.
+- Conditional rendering: avoid nested ternaries. Break complex conditionals into separate components.
+- PropTypes are not required in TypeScript projects — use TypeScript types instead.
+
+---
+
+## CSS / Sass
+
+- Use Sass (SCSS syntax). Write CSS as close to standard CSS as possible; use Sass features only where they add clarity.
+- Do not use vendor mixin libraries (Compass, Bourbon). Use Autoprefixer in the build pipeline instead.
+- Do not write vendor prefixes manually in `.scss` files.
+- Architecture follows SMACSS: Settings → Base → Layout → Modules → Helpers.
+  - State classes: prefix with `is-` or `has-`.
+  - Subcomponents: `[module]-[subcomponent]`.
+  - Modifiers: `[module]--[modifier]`.
+- Name selectors based on function, not appearance. Lowercase, hyphen-separated.
+- Do not use IDs as styling hooks. Use class names.
+- Keep specificity low. Author from general to specific.
+- Nest no more than 3 levels deep (including pseudo-classes and pseudo-elements).
+- Do not use `!important` except to override unmodifiable third-party styles (add a comment explaining why).
+- Use `box-sizing: border-box` globally via the inherit pattern.
+- Use relative units (`em`, `rem`, `%`) over `px` wherever possible.
+- Do not use `line-height` with a unit. Use a unitless ratio (e.g., `line-height: 1.5`).
+- Use Sass modules (`@use`, `@forward`). Do not use the deprecated `@import`.
+- Declaration order inside a rule: `@extend` → `@include` → regular properties → pseudo-classes/elements → nested selectors → media queries.
+- Name and place media queries alongside their base ruleset, smallest to largest (mobile-first).
+
+### Partial naming convention
+
+`_[category].[partial-name].scss`
+
+Examples: `_settings.variables.scss`, `_layout.grid.scss`, `_module.card.scss`, `_helpers.spacing.scss`
+
+---
+
+## HTML
+
+- All HTML must conform to the HTML5 spec. Validate with the W3C validator.
+- Write semantic markup. Use the correct element for the meaning, not for the appearance.
+- Use HTML5 sectioning elements (`<header>`, `<main>`, `<article>`, `<aside>`, `<nav>`, `<footer>`).
+- All elements and attribute names must be lowercase. Attribute values in double quotes. All tags closed.
+- Attribute order: `class` → `id`/`name` → `data-*` → `src`/`for`/`type`/`href`/`value` → `title`/`alt` → `aria-*`/`role`.
+- Use `<button>` for actions, `<a>` for navigation. Use `type="button"` on `<button>` elements outside of forms.
+- Never use inline styles or inline event handlers. Hook JavaScript behavior via `data-*` attributes.
+- Use `<label>` for every form field, explicitly associated via `for`/`id`.
+- Do not use presentational elements (`<font>`, `<center>`, etc.) or attributes (`align`, `valign`).
+- Do not set `maximum-scale` or `user-scalable=no` in the viewport meta tag.
+
+---
+
+## Accessibility
+
+Target WCAG 2.2 Level AA compliance on all projects.
+
+- Always declare the page language: `<html lang="en">`.
+- Heading hierarchy must be logical and sequential. One `<h1>` per page. Do not choose heading levels based on visual size.
+- Text contrast: 4.5:1 minimum for normal text; 3:1 for large or bold text.
+- Every interactive element must be keyboard-accessible. Never remove the default focus outline without replacing it with a clearly visible alternative.
+- Provide a visually-hidden "Skip to main content" link as the first focusable element on each page.
+- Use ARIA attributes only when native HTML semantics are insufficient. Incorrect ARIA is worse than no ARIA.
+- Use `aria-haspopup`, `aria-expanded`, and `aria-hidden` to communicate toggle state.
+- Bind keyboard events (`focus`, `keydown`) alongside mouse events. Do not rely on hover-only interactions.
+- All `<img>` elements must have an `alt` attribute. Decorative images use `alt=""`.
+- Do not use color alone to convey information.
+- Error validation fires on submit, not on keystroke or blur. On error: move focus to the first invalid field, set `aria-invalid="true"`, link to the error message via `aria-describedby`.
+- Use `aria-required="true"` on required fields; do not rely solely on the HTML5 `required` attribute.
+- Test with: VoiceOver (macOS/iOS), NVDA + Firefox (Windows), TalkBack (Android). Use the axe browser extension for automated checks.
+
+---
+
+## Git
+
+### Branches
+
+- Branch names: `feature/TICKET-000-short-description` or `fix/TICKET-000-short-description`.
+- Use hyphens to separate words. Keep names short and descriptive.
+- Delete branches after merging.
+
+### Commits
+
+- Each commit = one logical change. Do not combine unrelated changes.
+- Commit early and often. Small, self-contained commits are easier to revert.
+- Use [Conventional Commits](https://www.conventionalcommits.org/) format:
+  ```
+  feat(scope): add user avatar upload
+  fix(auth): handle expired token on refresh
+  ```
+- Reference ticket IDs in the commit body when relevant.
+- Do not push half-done work. Use `git stash` instead.
+
+### Merging
+
+- Rebase personal branches onto the target branch before merging to keep history linear.
+- Use `--no-ff` when merging a branch with multiple commits.
+- Never force-push to a shared branch unless the entire team is aware and coordinated.
+- Never rewrite history on `main` or any production/CI branch.
+
+### Pull Requests
+
+Every PR must include:
+
+- **Summary** — what changed and why
+- **Testing instructions** — how to verify the change
+- **Ticket link(s)**
+- **Screenshots or recordings** for any UI/UX changes
+- **Checklist** confirming tests pass, linting is clean, and accessibility was considered
+
+Use CI/CD to run linting, type checks, and tests automatically on every PR. Do not merge a PR with failing checks.
+
+---
+
+## Security
+
+- Never commit secrets, API keys, credentials, or `.env` files. Use environment variables and a secrets manager.
+- Validate and sanitize all user input at the boundary. Do not trust client-supplied data server-side.
+- Follow OWASP Top 10 guidance. Pay particular attention to XSS, CSRF, and injection.
+- Set least-privilege access for all roles and service accounts.
+- Remove unused code, dependencies, and assets before shipping.
+- Strip metadata from SVGs before committing.
+
+---
+
+## Code Review Expectations
+
+When reviewing or generating code for PR review:
+
+- Check for logic errors, edge cases, and unhandled states.
+- Flag any use of `any`, non-null assertions, or type assertions without comments.
+- Confirm accessibility requirements are met for any UI changes.
+- Confirm no secrets or credentials are present.
+- Confirm the PR description matches the diff.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,19 +24,30 @@ These instructions apply to all AI-assisted coding at Think Company. They encode
 - Keep type definitions co-located with the code that uses them. Only promote to a shared `types/` directory when truly shared.
 - Avoid type assertions (`as Foo`) except at verified system boundaries. Never use non-null assertions (`!`) without a comment explaining why the value cannot be null.
 - Prefer `satisfies` over `as` when you need to validate a value against a type without widening it.
+- Use `as const` to lock object and tuple literals to their narrowest types (e.g. to derive a union from an array of values).
+- Model mutually-exclusive states as discriminated unions (a shared literal `kind`/`status` tag), not a bag of optional fields. Narrow them with `switch`.
+- For data crossing a system boundary (API responses, form input, `localStorage`), type it as `unknown` and validate at runtime with a schema validator (Zod or Valibot) before use. Do not trust a hand-written `as` cast on external data.
+- Enable `noUncheckedIndexedAccess` so indexed access (`arr[i]`, `record[key]`) is typed as possibly `undefined`. Consider `exactOptionalPropertyTypes` per project — it is stricter and can fight library interop.
 
 ---
 
 ## JavaScript
 
 - Use `const` by default. Use `let` only when the value will be reassigned. Never use `var`.
+- Declare variables close to where they are first used, not in a block at the top of the scope.
 - Use `===` and `!==`. Never `==` or `!=`.
+- Be explicit in conditions when the type is ambiguous. Truthy shortcuts hide bugs around `0`, `''`, and `null` — prefer `if (count > 0)` over `if (count)` and `if (name != null)` over `if (name)`.
 - Use template literals for string interpolation. No string concatenation.
 - Arrow functions for callbacks and closures. Named function declarations for top-level functions (better stack traces).
+- Use ES modules (`import`/`export`). Prefer named exports over default exports for non-component modules.
+- Use the modern operators: optional chaining (`?.`), nullish coalescing (`??`), and logical assignment (`??=`, `||=`, `&&=`). Use `??` (not `||`) for defaults so `0` and `''` are preserved.
+- Use `async`/`await` over hand-rolled promise chains. Run independent async work concurrently with `Promise.all`; use `Promise.allSettled` when failures should not short-circuit. Sequential `await`s on independent calls are a performance bug.
+- Iterate with `for...of` and array methods. Never use `for...in`; use `Object.keys`/`Object.values`/`Object.entries` for objects.
+- Bind events with `addEventListener` — never inline `on*` attributes. Use `IntersectionObserver`/`ResizeObserver` instead of polling `scroll`/`resize`; debounce or throttle high-frequency handlers.
+- Use trailing commas in multi-line objects, arrays, and parameter lists.
+- When converting strings to numbers, use `Number()` or `Number.parseInt(value, 10)` with an explicit radix.
 - Never use `eval` or the `Function` constructor.
 - Avoid assignments inside conditionals.
-- Wrap immediately-invoked function expressions in parentheses.
-- Do not bind to scroll or resize events without debouncing.
 
 ---
 
@@ -49,21 +60,27 @@ These instructions apply to all AI-assisted coding at Think Company. They encode
 - Use double quotes for JSX attributes; single quotes for all other JS/TS strings.
 - Do not use array index as `key` prop. Use a stable, unique ID.
 - Do not spread props onto DOM elements without filtering (`{...rest}` onto a `<div>` leaks unknown attributes).
-- State management:
-  - Single component: `useState`
-  - Component trees (2+ levels): React Context
-  - Application-wide: Redux with Redux Toolkit (RTK)
+- State management — match the tool to the *kind* of state:
+  - Local component state: `useState` (or `useReducer` for complex transitions).
+  - Shared across a small subtree: React Context. Do not reach for a global store just to avoid prop drilling.
+  - Server state (API data, caching, revalidation): TanStack Query or SWR. Do not put server data in Redux.
+  - URL state (filters, pagination): keep it in query params via the router.
+  - Global client state: Zustand or Jotai for lighter needs; Redux Toolkit (RTK) on larger projects.
+- `useEffect` is for synchronizing with external systems, not for deriving data. Compute derived values during render — do not mirror props into state via an effect. Declare every reactive dependency (do not disable `react-hooks/exhaustive-deps`), and return a cleanup function for subscriptions, timers, and connections.
+- Extract reusable stateful logic into custom hooks (`use`-prefixed), not HOCs or render props.
+- Wrap failure-prone subtrees (data fetching, third-party widgets, route components) in an error boundary.
+- In React 19 / Next.js App Router, components are Server Components by default. Mark components that use state, effects, or browser APIs with `'use client'`, and push client components as far down the tree as possible.
 - Do not use `isMounted`. It is deprecated and unavailable in functional components.
 - Conditional rendering: avoid nested ternaries. Break complex conditionals into separate components.
 - PropTypes are not required in TypeScript projects — use TypeScript types instead.
 
 ---
 
-## CSS / Sass
+## CSS
 
-- Use Sass (SCSS syntax). Write CSS as close to standard CSS as possible; use Sass features only where they add clarity.
-- Do not use vendor mixin libraries (Compass, Bourbon). Use Autoprefixer in the build pipeline instead.
-- Do not write vendor prefixes manually in `.scss` files.
+- Author **vanilla CSS** on all projects. Use **Tailwind CSS** as a utility layer where the project and client permit. Sass/SCSS is no longer the default — projects already on Sass may continue, but do not start new work in it.
+- Use CSS custom properties for all design tokens (colors, spacing, type scale, z-index, breakpoints). Define them on `:root`.
+- Do not use vendor mixin libraries. Avoid manual vendor prefixes — use Autoprefixer in the build pipeline.
 - Architecture follows SMACSS: Settings → Base → Layout → Modules → Helpers.
   - State classes: prefix with `is-` or `has-`.
   - Subcomponents: `[module]-[subcomponent]`.
@@ -76,15 +93,32 @@ These instructions apply to all AI-assisted coding at Think Company. They encode
 - Use `box-sizing: border-box` globally via the inherit pattern.
 - Use relative units (`em`, `rem`, `%`) over `px` wherever possible.
 - Do not use `line-height` with a unit. Use a unitless ratio (e.g., `line-height: 1.5`).
-- Use Sass modules (`@use`, `@forward`). Do not use the deprecated `@import`.
-- Declaration order inside a rule: `@extend` → `@include` → regular properties → pseudo-classes/elements → nested selectors → media queries.
+- Declaration order within a rule: custom properties → layout → box model → typography → visual → interaction → animation.
 - Name and place media queries alongside their base ruleset, smallest to largest (mobile-first).
 
-### Partial naming convention
+### File naming convention
 
-`_[category].[partial-name].scss`
+`[category].[partial-name].css`
 
-Examples: `_settings.variables.scss`, `_layout.grid.scss`, `_module.card.scss`, `_helpers.spacing.scss`
+Examples: `settings.tokens.css`, `layout.grid.css`, `module.card.css`, `helpers.spacing.css`
+
+### Tailwind
+
+- Use Tailwind only where the team has agreed and no conflicting CSS architecture exists.
+- Order utility classes layout → box model → typography → visual → interaction → animation; enforce with the Prettier Tailwind plugin.
+- Prefer extracting a reusable component over `@apply`. Use `@apply` only where JSX components aren't available (e.g. CMS templates).
+- Map tokens in config to custom properties; don't use arbitrary values (`w-[347px]`) for things that should be tokens.
+
+### Modern CSS features
+
+These have reached broad/Baseline support — treat them as first-class tools, not experimental:
+
+- **Cascade layers (`@layer`)** to manage specificity across resets, third-party styles, and your own code without `!important`.
+- **Container queries** when a component's layout depends on its container's size rather than the viewport.
+- **`:has()`** to style a parent based on its descendants — replaces many JS class-toggling patterns.
+- **Logical properties** (`margin-inline`, `padding-block`, `border-inline-start`) over physical ones for RTL-friendly layouts.
+- **Modern color** — `oklch()` for perceptually-uniform colors, `color-mix()` to derive related colors from a token.
+- **Custom properties** for all design tokens (colors, spacing, type scale, z-index).
 
 ---
 
@@ -93,7 +127,7 @@ Examples: `_settings.variables.scss`, `_layout.grid.scss`, `_module.card.scss`, 
 - All HTML must conform to the HTML5 spec. Validate with the W3C validator.
 - Write semantic markup. Use the correct element for the meaning, not for the appearance.
 - Use HTML5 sectioning elements (`<header>`, `<main>`, `<article>`, `<aside>`, `<nav>`, `<footer>`).
-- All elements and attribute names must be lowercase. Attribute values in double quotes. All tags closed.
+- All elements and attribute names must be lowercase. Attribute values in double quotes. Void elements (`<img>`, `<input>`, `<br>`, etc.) do not need a trailing slash — that's an XHTML convention.
 - Attribute order: `class` → `id`/`name` → `data-*` → `src`/`for`/`type`/`href`/`value` → `title`/`alt` → `aria-*`/`role`.
 - Use `<button>` for actions, `<a>` for navigation. Use `type="button"` on `<button>` elements outside of forms.
 - Never use inline styles or inline event handlers. Hook JavaScript behavior via `data-*` attributes.
@@ -110,7 +144,9 @@ Target WCAG 2.2 Level AA compliance on all projects.
 - Always declare the page language: `<html lang="en">`.
 - Heading hierarchy must be logical and sequential. One `<h1>` per page. Do not choose heading levels based on visual size.
 - Text contrast: 4.5:1 minimum for normal text; 3:1 for large or bold text.
-- Every interactive element must be keyboard-accessible. Never remove the default focus outline without replacing it with a clearly visible alternative.
+- Every interactive element must be keyboard-accessible. Never remove the default focus outline without replacing it with a clearly visible alternative. Prefer `:focus-visible` over `:focus` so mouse clicks don't show a stray ring. Focus indicators need at least a 2px outline at 3:1 contrast (WCAG 2.2 SC 2.4.11/2.4.13).
+- Interactive targets must be at least 24×24 CSS pixels (WCAG 2.2 SC 2.5.8); 44×44 is the AAA/design-system target.
+- Wrap non-essential animation in `@media (prefers-reduced-motion: reduce)` and disable it there.
 - Provide a visually-hidden "Skip to main content" link as the first focusable element on each page.
 - Use ARIA attributes only when native HTML semantics are insufficient. Incorrect ARIA is worse than no ARIA.
 - Use `aria-haspopup`, `aria-expanded`, and `aria-hidden` to communicate toggle state.
@@ -118,7 +154,7 @@ Target WCAG 2.2 Level AA compliance on all projects.
 - All `<img>` elements must have an `alt` attribute. Decorative images use `alt=""`.
 - Do not use color alone to convey information.
 - Error validation fires on submit, not on keystroke or blur. On error: move focus to the first invalid field, set `aria-invalid="true"`, link to the error message via `aria-describedby`.
-- Use `aria-required="true"` on required fields; do not rely solely on the HTML5 `required` attribute.
+- Use the native HTML `required` attribute as the source of truth for required fields — it is well-supported by current screen readers and gives free browser validation. `aria-required="true"` is redundant when `required` is present; use it only on custom widgets that can't use the native attribute.
 - Test with: VoiceOver (macOS/iOS), NVDA + Firefox (Windows), TalkBack (Android). Use the axe browser extension for automated checks.
 
 ---
@@ -166,12 +202,16 @@ Use CI/CD to run linting, type checks, and tests automatically on every PR. Do n
 
 ## Security
 
-- Never commit secrets, API keys, credentials, or `.env` files. Use environment variables and a secrets manager.
-- Validate and sanitize all user input at the boundary. Do not trust client-supplied data server-side.
-- Follow OWASP Top 10 guidance. Pay particular attention to XSS, CSRF, and injection.
-- Set least-privilege access for all roles and service accounts.
+- Never commit secrets, API keys, credentials, or `.env` files. Use environment variables and a secrets manager. Run a secret-scanning hook (e.g. gitleaks). If a secret reaches version control, rotate it first, then scrub history.
+- Validate and sanitize all user input at the boundary. Do not trust client-supplied data server-side. Never build SQL or shell commands via string concatenation — use parameterized queries.
+- Follow OWASP Top 10 guidance. Pay particular attention to XSS, CSRF, injection, and supply-chain attacks.
+- Set a Content Security Policy (CSP) — prefer nonce/hash allowlisting over `'unsafe-inline'`. It is one of the highest-leverage XSS defenses.
+- Add Subresource Integrity (`integrity="sha384-…"`) to third-party scripts loaded from a CDN you don't control.
+- Serve over HTTPS and send `Strict-Transport-Security` (HSTS).
+- Automate dependency scanning (Dependabot or Renovate, plus `npm audit`/Snyk in CI). Review lockfile changes carefully — pin versions.
+- Set least-privilege access for all roles, service accounts, and CI tokens.
 - Remove unused code, dependencies, and assets before shipping.
-- Strip metadata from SVGs before committing.
+- Strip metadata from SVGs before committing. Any process accepting user-uploaded SVGs must sanitize embedded `<script>` and event-handler attributes.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,197 @@
+# Think Company — AI Agent Coding Instructions
+
+These instructions apply to all AI-assisted coding at Think Company. They encode our front-end development standards and are the authoritative source for the per-tool files (`CLAUDE.md`, `.cursor/rules/`, `.github/copilot-instructions.md`).
+
+---
+
+## Core Principles
+
+- Write code that is readable, modular, and accessible by default.
+- Prefer explicit over clever. Prioritize the next developer's ability to understand and change the code.
+- Follow the conventions already in use in the project. When in doubt, match the surrounding code.
+- Do not add features, abstractions, or error handling beyond what the task requires.
+- Validate at system boundaries (user input, external APIs). Trust internal code.
+
+---
+
+## TypeScript
+
+- All new code must be TypeScript. Do not introduce plain `.js` files.
+- Enable `strict: true` in `tsconfig.json`. Never disable strict mode to work around a type error — fix the type.
+- Never use `any`. Prefer `unknown` when the type is genuinely unknown and narrow it explicitly.
+- Prefer `interface` for object shapes that may be extended; use `type` for unions, intersections, and aliases.
+- Use built-in utility types (`Partial`, `Required`, `Pick`, `Omit`, `Readonly`, `ReturnType`, etc.) rather than re-implementing them.
+- Keep type definitions co-located with the code that uses them. Only promote to a shared `types/` directory when truly shared.
+- Avoid type assertions (`as Foo`) except at verified system boundaries. Never use non-null assertions (`!`) without a comment explaining why the value cannot be null.
+- Prefer `satisfies` over `as` when you need to validate a value against a type without widening it.
+
+---
+
+## JavaScript
+
+- Use `const` by default. Use `let` only when the value will be reassigned. Never use `var`.
+- Use `===` and `!==`. Never `==` or `!=`.
+- Use template literals for string interpolation. No string concatenation.
+- Arrow functions for callbacks and closures. Named function declarations for top-level functions (better stack traces).
+- Never use `eval` or the `Function` constructor.
+- Avoid assignments inside conditionals.
+- Wrap immediately-invoked function expressions in parentheses.
+- Do not bind to scroll or resize events without debouncing.
+
+---
+
+## React
+
+- Use functional components exclusively. Do not write new class components.
+- Use hooks for all state and side effects. Do not use `componentWillMount`, `componentWillReceiveProps`, or other deprecated lifecycle methods.
+- One component per file. Filename and component name must match. Use PascalCase (e.g., `UserCard.tsx`).
+- Always use `.tsx` for files containing JSX.
+- Use double quotes for JSX attributes; single quotes for all other JS/TS strings.
+- Do not use array index as `key` prop. Use a stable, unique ID.
+- Do not spread props onto DOM elements without filtering (`{...rest}` onto a `<div>` leaks unknown attributes).
+- State management:
+  - Single component: `useState`
+  - Component trees (2+ levels): React Context
+  - Application-wide: Redux with Redux Toolkit (RTK)
+- Do not use `isMounted`. It is deprecated and unavailable in functional components.
+- Conditional rendering: avoid nested ternaries. Break complex conditionals into separate components.
+- PropTypes are not required in TypeScript projects — use TypeScript types instead.
+
+---
+
+## CSS / Sass
+
+- Use Sass (SCSS syntax). Write CSS as close to standard CSS as possible; use Sass features only where they add clarity.
+- Do not use vendor mixin libraries (Compass, Bourbon). Use Autoprefixer in the build pipeline instead.
+- Do not write vendor prefixes manually in `.scss` files.
+- Architecture follows SMACSS: Settings → Base → Layout → Modules → Helpers.
+  - State classes: prefix with `is-` or `has-`.
+  - Subcomponents: `[module]-[subcomponent]`.
+  - Modifiers: `[module]--[modifier]`.
+- Name selectors based on function, not appearance. Lowercase, hyphen-separated.
+- Do not use IDs as styling hooks. Use class names.
+- Keep specificity low. Author from general to specific.
+- Nest no more than 3 levels deep (including pseudo-classes and pseudo-elements).
+- Do not use `!important` except to override unmodifiable third-party styles (add a comment explaining why).
+- Use `box-sizing: border-box` globally via the inherit pattern.
+- Use relative units (`em`, `rem`, `%`) over `px` wherever possible.
+- Do not use `line-height` with a unit. Use a unitless ratio (e.g., `line-height: 1.5`).
+- Use Sass modules (`@use`, `@forward`). Do not use the deprecated `@import`.
+- Declaration order inside a rule: `@extend` → `@include` → regular properties → pseudo-classes/elements → nested selectors → media queries.
+- Name and place media queries alongside their base ruleset, smallest to largest (mobile-first).
+
+### Partial naming convention
+
+`_[category].[partial-name].scss`
+
+Examples: `_settings.variables.scss`, `_layout.grid.scss`, `_module.card.scss`, `_helpers.spacing.scss`
+
+---
+
+## HTML
+
+- All HTML must conform to the HTML5 spec. Validate with the W3C validator.
+- Write semantic markup. Use the correct element for the meaning, not for the appearance.
+- Use HTML5 sectioning elements (`<header>`, `<main>`, `<article>`, `<aside>`, `<nav>`, `<footer>`).
+- All elements and attribute names must be lowercase. Attribute values in double quotes. All tags closed.
+- Attribute order: `class` → `id`/`name` → `data-*` → `src`/`for`/`type`/`href`/`value` → `title`/`alt` → `aria-*`/`role`.
+- Use `<button>` for actions, `<a>` for navigation. Use `type="button"` on `<button>` elements outside of forms.
+- Never use inline styles or inline event handlers. Hook JavaScript behavior via `data-*` attributes.
+- Use `<label>` for every form field, explicitly associated via `for`/`id`.
+- Do not use presentational elements (`<font>`, `<center>`, etc.) or attributes (`align`, `valign`).
+- Do not set `maximum-scale` or `user-scalable=no` in the viewport meta tag.
+
+---
+
+## Accessibility
+
+Target WCAG 2.2 Level AA compliance on all projects.
+
+- Always declare the page language: `<html lang="en">`.
+- Heading hierarchy must be logical and sequential. One `<h1>` per page. Do not choose heading levels based on visual size.
+- Text contrast: 4.5:1 minimum for normal text; 3:1 for large or bold text.
+- Every interactive element must be keyboard-accessible. Never remove the default focus outline without replacing it with a clearly visible alternative.
+- Provide a visually-hidden "Skip to main content" link as the first focusable element on each page.
+- Use ARIA attributes only when native HTML semantics are insufficient. Incorrect ARIA is worse than no ARIA.
+- Use `aria-haspopup`, `aria-expanded`, and `aria-hidden` to communicate toggle state.
+- Bind keyboard events (`focus`, `keydown`) alongside mouse events. Do not rely on hover-only interactions.
+- All `<img>` elements must have an `alt` attribute. Decorative images use `alt=""`.
+- Do not use color alone to convey information.
+- Error validation fires on submit, not on keystroke or blur. On error: move focus to the first invalid field, set `aria-invalid="true"`, link to the error message via `aria-describedby`.
+- Use `aria-required="true"` on required fields; do not rely solely on the HTML5 `required` attribute.
+- Test with: VoiceOver (macOS/iOS), NVDA + Firefox (Windows), TalkBack (Android). Use the axe browser extension for automated checks.
+
+---
+
+## Git
+
+### Branches
+
+- Branch names: `feature/TICKET-000-short-description` or `fix/TICKET-000-short-description`.
+- Use hyphens to separate words. Keep names short and descriptive.
+- Delete branches after merging.
+
+### Commits
+
+- Each commit = one logical change. Do not combine unrelated changes.
+- Commit early and often. Small, self-contained commits are easier to revert.
+- Use [Conventional Commits](https://www.conventionalcommits.org/) format:
+  ```
+  feat(scope): add user avatar upload
+  fix(auth): handle expired token on refresh
+  ```
+- Reference ticket IDs in the commit body when relevant.
+- Do not push half-done work. Use `git stash` instead.
+
+### Merging
+
+- Rebase personal branches onto the target branch before merging to keep history linear.
+- Use `--no-ff` when merging a branch with multiple commits.
+- Never force-push to a shared branch unless the entire team is aware and coordinated.
+- Never rewrite history on `main` or any production/CI branch.
+
+### Pull Requests
+
+Every PR must include:
+
+- **Summary** — what changed and why
+- **Testing instructions** — how to verify the change
+- **Ticket link(s)**
+- **Screenshots or recordings** for any UI/UX changes
+- **Checklist** confirming tests pass, linting is clean, and accessibility was considered
+
+Use CI/CD to run linting, type checks, and tests automatically on every PR. Do not merge a PR with failing checks.
+
+---
+
+## Security
+
+- Never commit secrets, API keys, credentials, or `.env` files. Use environment variables and a secrets manager.
+- Validate and sanitize all user input at the boundary. Do not trust client-supplied data server-side.
+- Follow OWASP Top 10 guidance. Pay particular attention to XSS, CSRF, and injection.
+- Set least-privilege access for all roles and service accounts.
+- Remove unused code, dependencies, and assets before shipping.
+- Strip metadata from SVGs before committing.
+
+---
+
+## Code Review Expectations
+
+When reviewing or generating code for PR review:
+
+- Check for logic errors, edge cases, and unhandled states.
+- Flag any use of `any`, non-null assertions, or type assertions without comments.
+- Confirm accessibility requirements are met for any UI changes.
+- Confirm no secrets or credentials are present.
+- Confirm the PR description matches the diff.
+
+---
+
+## Claude-specific behavior
+
+- Do not create planning or analysis documents unless explicitly asked. Work from conversation context.
+- Do not add comments explaining what the code does. Add a comment only when the WHY is non-obvious.
+- Do not summarize what you just did at the end of a response. The diff speaks for itself.
+- Default to editing existing files. Only create new files when the task requires it.
+- Do not add features, refactors, or abstractions beyond the stated task.
+- Run the type checker and linter before reporting a task complete.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,19 +24,30 @@ These instructions apply to all AI-assisted coding at Think Company. They encode
 - Keep type definitions co-located with the code that uses them. Only promote to a shared `types/` directory when truly shared.
 - Avoid type assertions (`as Foo`) except at verified system boundaries. Never use non-null assertions (`!`) without a comment explaining why the value cannot be null.
 - Prefer `satisfies` over `as` when you need to validate a value against a type without widening it.
+- Use `as const` to lock object and tuple literals to their narrowest types (e.g. to derive a union from an array of values).
+- Model mutually-exclusive states as discriminated unions (a shared literal `kind`/`status` tag), not a bag of optional fields. Narrow them with `switch`.
+- For data crossing a system boundary (API responses, form input, `localStorage`), type it as `unknown` and validate at runtime with a schema validator (Zod or Valibot) before use. Do not trust a hand-written `as` cast on external data.
+- Enable `noUncheckedIndexedAccess` so indexed access (`arr[i]`, `record[key]`) is typed as possibly `undefined`. Consider `exactOptionalPropertyTypes` per project — it is stricter and can fight library interop.
 
 ---
 
 ## JavaScript
 
 - Use `const` by default. Use `let` only when the value will be reassigned. Never use `var`.
+- Declare variables close to where they are first used, not in a block at the top of the scope.
 - Use `===` and `!==`. Never `==` or `!=`.
+- Be explicit in conditions when the type is ambiguous. Truthy shortcuts hide bugs around `0`, `''`, and `null` — prefer `if (count > 0)` over `if (count)` and `if (name != null)` over `if (name)`.
 - Use template literals for string interpolation. No string concatenation.
 - Arrow functions for callbacks and closures. Named function declarations for top-level functions (better stack traces).
+- Use ES modules (`import`/`export`). Prefer named exports over default exports for non-component modules.
+- Use the modern operators: optional chaining (`?.`), nullish coalescing (`??`), and logical assignment (`??=`, `||=`, `&&=`). Use `??` (not `||`) for defaults so `0` and `''` are preserved.
+- Use `async`/`await` over hand-rolled promise chains. Run independent async work concurrently with `Promise.all`; use `Promise.allSettled` when failures should not short-circuit. Sequential `await`s on independent calls are a performance bug.
+- Iterate with `for...of` and array methods. Never use `for...in`; use `Object.keys`/`Object.values`/`Object.entries` for objects.
+- Bind events with `addEventListener` — never inline `on*` attributes. Use `IntersectionObserver`/`ResizeObserver` instead of polling `scroll`/`resize`; debounce or throttle high-frequency handlers.
+- Use trailing commas in multi-line objects, arrays, and parameter lists.
+- When converting strings to numbers, use `Number()` or `Number.parseInt(value, 10)` with an explicit radix.
 - Never use `eval` or the `Function` constructor.
 - Avoid assignments inside conditionals.
-- Wrap immediately-invoked function expressions in parentheses.
-- Do not bind to scroll or resize events without debouncing.
 
 ---
 
@@ -49,21 +60,27 @@ These instructions apply to all AI-assisted coding at Think Company. They encode
 - Use double quotes for JSX attributes; single quotes for all other JS/TS strings.
 - Do not use array index as `key` prop. Use a stable, unique ID.
 - Do not spread props onto DOM elements without filtering (`{...rest}` onto a `<div>` leaks unknown attributes).
-- State management:
-  - Single component: `useState`
-  - Component trees (2+ levels): React Context
-  - Application-wide: Redux with Redux Toolkit (RTK)
+- State management — match the tool to the *kind* of state:
+  - Local component state: `useState` (or `useReducer` for complex transitions).
+  - Shared across a small subtree: React Context. Do not reach for a global store just to avoid prop drilling.
+  - Server state (API data, caching, revalidation): TanStack Query or SWR. Do not put server data in Redux.
+  - URL state (filters, pagination): keep it in query params via the router.
+  - Global client state: Zustand or Jotai for lighter needs; Redux Toolkit (RTK) on larger projects.
+- `useEffect` is for synchronizing with external systems, not for deriving data. Compute derived values during render — do not mirror props into state via an effect. Declare every reactive dependency (do not disable `react-hooks/exhaustive-deps`), and return a cleanup function for subscriptions, timers, and connections.
+- Extract reusable stateful logic into custom hooks (`use`-prefixed), not HOCs or render props.
+- Wrap failure-prone subtrees (data fetching, third-party widgets, route components) in an error boundary.
+- In React 19 / Next.js App Router, components are Server Components by default. Mark components that use state, effects, or browser APIs with `'use client'`, and push client components as far down the tree as possible.
 - Do not use `isMounted`. It is deprecated and unavailable in functional components.
 - Conditional rendering: avoid nested ternaries. Break complex conditionals into separate components.
 - PropTypes are not required in TypeScript projects — use TypeScript types instead.
 
 ---
 
-## CSS / Sass
+## CSS
 
-- Use Sass (SCSS syntax). Write CSS as close to standard CSS as possible; use Sass features only where they add clarity.
-- Do not use vendor mixin libraries (Compass, Bourbon). Use Autoprefixer in the build pipeline instead.
-- Do not write vendor prefixes manually in `.scss` files.
+- Author **vanilla CSS** on all projects. Use **Tailwind CSS** as a utility layer where the project and client permit. Sass/SCSS is no longer the default — projects already on Sass may continue, but do not start new work in it.
+- Use CSS custom properties for all design tokens (colors, spacing, type scale, z-index, breakpoints). Define them on `:root`.
+- Do not use vendor mixin libraries. Avoid manual vendor prefixes — use Autoprefixer in the build pipeline.
 - Architecture follows SMACSS: Settings → Base → Layout → Modules → Helpers.
   - State classes: prefix with `is-` or `has-`.
   - Subcomponents: `[module]-[subcomponent]`.
@@ -76,15 +93,32 @@ These instructions apply to all AI-assisted coding at Think Company. They encode
 - Use `box-sizing: border-box` globally via the inherit pattern.
 - Use relative units (`em`, `rem`, `%`) over `px` wherever possible.
 - Do not use `line-height` with a unit. Use a unitless ratio (e.g., `line-height: 1.5`).
-- Use Sass modules (`@use`, `@forward`). Do not use the deprecated `@import`.
-- Declaration order inside a rule: `@extend` → `@include` → regular properties → pseudo-classes/elements → nested selectors → media queries.
+- Declaration order within a rule: custom properties → layout → box model → typography → visual → interaction → animation.
 - Name and place media queries alongside their base ruleset, smallest to largest (mobile-first).
 
-### Partial naming convention
+### File naming convention
 
-`_[category].[partial-name].scss`
+`[category].[partial-name].css`
 
-Examples: `_settings.variables.scss`, `_layout.grid.scss`, `_module.card.scss`, `_helpers.spacing.scss`
+Examples: `settings.tokens.css`, `layout.grid.css`, `module.card.css`, `helpers.spacing.css`
+
+### Tailwind
+
+- Use Tailwind only where the team has agreed and no conflicting CSS architecture exists.
+- Order utility classes layout → box model → typography → visual → interaction → animation; enforce with the Prettier Tailwind plugin.
+- Prefer extracting a reusable component over `@apply`. Use `@apply` only where JSX components aren't available (e.g. CMS templates).
+- Map tokens in config to custom properties; don't use arbitrary values (`w-[347px]`) for things that should be tokens.
+
+### Modern CSS features
+
+These have reached broad/Baseline support — treat them as first-class tools, not experimental:
+
+- **Cascade layers (`@layer`)** to manage specificity across resets, third-party styles, and your own code without `!important`.
+- **Container queries** when a component's layout depends on its container's size rather than the viewport.
+- **`:has()`** to style a parent based on its descendants — replaces many JS class-toggling patterns.
+- **Logical properties** (`margin-inline`, `padding-block`, `border-inline-start`) over physical ones for RTL-friendly layouts.
+- **Modern color** — `oklch()` for perceptually-uniform colors, `color-mix()` to derive related colors from a token.
+- **Custom properties** for all design tokens (colors, spacing, type scale, z-index).
 
 ---
 
@@ -93,7 +127,7 @@ Examples: `_settings.variables.scss`, `_layout.grid.scss`, `_module.card.scss`, 
 - All HTML must conform to the HTML5 spec. Validate with the W3C validator.
 - Write semantic markup. Use the correct element for the meaning, not for the appearance.
 - Use HTML5 sectioning elements (`<header>`, `<main>`, `<article>`, `<aside>`, `<nav>`, `<footer>`).
-- All elements and attribute names must be lowercase. Attribute values in double quotes. All tags closed.
+- All elements and attribute names must be lowercase. Attribute values in double quotes. Void elements (`<img>`, `<input>`, `<br>`, etc.) do not need a trailing slash — that's an XHTML convention.
 - Attribute order: `class` → `id`/`name` → `data-*` → `src`/`for`/`type`/`href`/`value` → `title`/`alt` → `aria-*`/`role`.
 - Use `<button>` for actions, `<a>` for navigation. Use `type="button"` on `<button>` elements outside of forms.
 - Never use inline styles or inline event handlers. Hook JavaScript behavior via `data-*` attributes.
@@ -110,7 +144,9 @@ Target WCAG 2.2 Level AA compliance on all projects.
 - Always declare the page language: `<html lang="en">`.
 - Heading hierarchy must be logical and sequential. One `<h1>` per page. Do not choose heading levels based on visual size.
 - Text contrast: 4.5:1 minimum for normal text; 3:1 for large or bold text.
-- Every interactive element must be keyboard-accessible. Never remove the default focus outline without replacing it with a clearly visible alternative.
+- Every interactive element must be keyboard-accessible. Never remove the default focus outline without replacing it with a clearly visible alternative. Prefer `:focus-visible` over `:focus` so mouse clicks don't show a stray ring. Focus indicators need at least a 2px outline at 3:1 contrast (WCAG 2.2 SC 2.4.11/2.4.13).
+- Interactive targets must be at least 24×24 CSS pixels (WCAG 2.2 SC 2.5.8); 44×44 is the AAA/design-system target.
+- Wrap non-essential animation in `@media (prefers-reduced-motion: reduce)` and disable it there.
 - Provide a visually-hidden "Skip to main content" link as the first focusable element on each page.
 - Use ARIA attributes only when native HTML semantics are insufficient. Incorrect ARIA is worse than no ARIA.
 - Use `aria-haspopup`, `aria-expanded`, and `aria-hidden` to communicate toggle state.
@@ -118,7 +154,7 @@ Target WCAG 2.2 Level AA compliance on all projects.
 - All `<img>` elements must have an `alt` attribute. Decorative images use `alt=""`.
 - Do not use color alone to convey information.
 - Error validation fires on submit, not on keystroke or blur. On error: move focus to the first invalid field, set `aria-invalid="true"`, link to the error message via `aria-describedby`.
-- Use `aria-required="true"` on required fields; do not rely solely on the HTML5 `required` attribute.
+- Use the native HTML `required` attribute as the source of truth for required fields — it is well-supported by current screen readers and gives free browser validation. `aria-required="true"` is redundant when `required` is present; use it only on custom widgets that can't use the native attribute.
 - Test with: VoiceOver (macOS/iOS), NVDA + Firefox (Windows), TalkBack (Android). Use the axe browser extension for automated checks.
 
 ---
@@ -166,12 +202,16 @@ Use CI/CD to run linting, type checks, and tests automatically on every PR. Do n
 
 ## Security
 
-- Never commit secrets, API keys, credentials, or `.env` files. Use environment variables and a secrets manager.
-- Validate and sanitize all user input at the boundary. Do not trust client-supplied data server-side.
-- Follow OWASP Top 10 guidance. Pay particular attention to XSS, CSRF, and injection.
-- Set least-privilege access for all roles and service accounts.
+- Never commit secrets, API keys, credentials, or `.env` files. Use environment variables and a secrets manager. Run a secret-scanning hook (e.g. gitleaks). If a secret reaches version control, rotate it first, then scrub history.
+- Validate and sanitize all user input at the boundary. Do not trust client-supplied data server-side. Never build SQL or shell commands via string concatenation — use parameterized queries.
+- Follow OWASP Top 10 guidance. Pay particular attention to XSS, CSRF, injection, and supply-chain attacks.
+- Set a Content Security Policy (CSP) — prefer nonce/hash allowlisting over `'unsafe-inline'`. It is one of the highest-leverage XSS defenses.
+- Add Subresource Integrity (`integrity="sha384-…"`) to third-party scripts loaded from a CDN you don't control.
+- Serve over HTTPS and send `Strict-Transport-Security` (HSTS).
+- Automate dependency scanning (Dependabot or Renovate, plus `npm audit`/Snyk in CI). Review lockfile changes carefully — pin versions.
+- Set least-privilege access for all roles, service accounts, and CI tokens.
 - Remove unused code, dependencies, and assets before shipping.
-- Strip metadata from SVGs before committing.
+- Strip metadata from SVGs before committing. Any process accepting user-uploaded SVGs must sanitize embedded `<script>` and event-handler attributes.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `AGENTS.md` as the canonical AI coding instructions file — single source of truth covering TypeScript, JavaScript, React, CSS/Sass, HTML, Accessibility, Git, Security, and Code Review expectations
- Adds `CLAUDE.md` (full embed of `AGENTS.md` + Claude Code-specific behavior rules)
- Adds `.cursor/rules/think-standards.mdc` (Cursor rule file with glob scoping)
- Adds `.github/copilot-instructions.md` (GitHub Copilot instructions)

`AGENTS.md` is the file to edit when standards change. `CLAUDE.md` should be kept in sync with it manually. The Cursor and Copilot files are intentional summaries and only need updating when a major section is added or removed.

## Test plan

- [ ] Drop `CLAUDE.md` into a project repo root and verify Claude Code picks it up
- [ ] Drop `.cursor/rules/think-standards.mdc` into a project and verify Cursor applies it to `.ts`/`.tsx` files
- [ ] Drop `.github/copilot-instructions.md` into a project and verify Copilot reflects the instructions in VS Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)