### PR TITLE
Add AI-Assisted Coding page to the standards site

### DIFF
--- a/.cursor/rules/think-standards.mdc
+++ b/.cursor/rules/think-standards.mdc
@@ -11,7 +11,7 @@ Follow all standards in `AGENTS.md` at the repo root.
 ## Key rules for Cursor
 
 - TypeScript only. `strict: true`. Never use `any` — use `unknown` and narrow. Validate external data with Zod/Valibot, not an `as` cast.
-- `const` by default, never `var`. Modern operators (`?.`, `??`, logical assignment). `async`/`await` over promise chains. `for...of`/`Object.entries`, never `for...in`.
+- `const` by default, never `var`. Modern operators (`?.`, `??`, logical assignment). `async`/`await` over promise chains. Array methods (`.map`/`.filter`/`.reduce`/etc.) for transformations, `for...of`/`Object.entries` for imperative iteration — never `for...in`.
 - Functional React components only. Hooks for state and effects. `useEffect` synchronizes with external systems — don't derive state in it; declare all deps; return cleanup.
 - Server state → TanStack Query/SWR (not Redux). Reusable logic → custom hooks. Wrap failure-prone subtrees in an error boundary.
 - WCAG 2.2 AA accessibility on all UI. `:focus-visible` focus states, targets ≥ 24×24px, respect `prefers-reduced-motion`. Native `required` over `aria-required`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,7 +14,7 @@ Follow the standards in `AGENTS.md` at the repo root. The rules below are a summ
 - Be explicit in conditions: `if (count > 0)` over `if (count)` — truthy shortcuts hide `0`/`''`/`null` bugs.
 - Modern operators: `?.`, `??` (not `||`) for defaults, logical assignment.
 - `async`/`await` over promise chains; `Promise.all` for independent work.
-- `for...of` and `Object.entries` — never `for...in`. Trailing commas in multiline.
+- Prefer functional array methods (`.map`, `.filter`, `.reduce`, `.some`, `.every`) for data transformation and side-effect-free logic. Use `for...of` for sequential asynchronous tasks or when early break/continue is necessary. `Object.entries` over `for...in`. Trailing commas in multiline.
 - `addEventListener` only; `IntersectionObserver`/`ResizeObserver` over scroll/resize polling.
 
 ## React

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ These instructions apply to all AI-assisted coding at Think Company. They encode
 - Use ES modules (`import`/`export`). Prefer named exports over default exports for non-component modules.
 - Use the modern operators: optional chaining (`?.`), nullish coalescing (`??`), and logical assignment (`??=`, `||=`, `&&=`). Use `??` (not `||`) for defaults so `0` and `''` are preserved.
 - Use `async`/`await` over hand-rolled promise chains. Run independent async work concurrently with `Promise.all`; use `Promise.allSettled` when failures should not short-circuit. Sequential `await`s on independent calls are a performance bug.
-- Iterate with `for...of` and array methods. Never use `for...in`; use `Object.keys`/`Object.values`/`Object.entries` for objects.
+- Prefer functional array methods (`.map`, `.filter`, `.reduce`, `.some`, `.every`) for data transformation and side-effect-free logic. Use `for...of` for sequential asynchronous tasks or when early break/continue is necessary. Never use `for...in`; use `Object.keys`/`Object.values`/`Object.entries` for objects.
 - Bind events with `addEventListener` — never inline `on*` attributes. Use `IntersectionObserver`/`ResizeObserver` instead of polling `scroll`/`resize`; debounce or throttle high-frequency handlers.
 - Use trailing commas in multi-line objects, arrays, and parameter lists.
 - When converting strings to numbers, use `Number()` or `Number.parseInt(value, 10)` with an explicit radix.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ To make updates to the static version of our docs site, you'll need to:
 - Run `npm start` to start the Gatsby development server.
 - Navigate to: [http://localhost:8000](http://localhost:8000) to get started.
 
+`npm run build`/`npm start` automatically run `copy:ai-files` first, which copies the canonical AI agent instruction files (`AGENTS.md`, `CLAUDE.md`, `.cursor/rules/think-standards.mdc`, `.github/copilot-instructions.md`) into `static/downloads/` so the `/ai/` page can serve them. Don't edit the files in `static/downloads/` directly — edit the source files at their original locations and the copies will regenerate.
+
 ## Environments
 - Production: [http://standards.thinkcompany.dev](http://standards.thinkcompany.dev)
 - Each branch pushed to `origin` results in [Netlify](https://www.netlify.com) building a branch deploy.

--- a/content/ai/index.mdx
+++ b/content/ai/index.mdx
@@ -12,6 +12,7 @@ This document covers how we work with AI coding assistants at Think Company and 
 
 - [Why Standardized AI Files](#why-standardized-ai-files)
 - [The Files](#the-files)
+- [Download the Files](#download-the-files)
 - [Per-Tool Setup](#per-tool-setup)
 - [Keeping Them in Sync](#keeping-them-in-sync)
 - [What's Inside](#whats-inside)
@@ -41,6 +42,15 @@ All four files live at the **root of each project repository**:
 | `.github/copilot-instructions.md` | GitHub Copilot | A condensed summary tuned for inline suggestions. |
 
 `AGENTS.md` is the authoritative document. `CLAUDE.md` is a complete embed of it (tools don't reliably follow file references, so it is duplicated rather than linked). The Cursor and Copilot files are intentional summaries.
+
+## Download the Files
+
+Grab the current version of any file and drop it into your project at the path shown above. These downloads are generated from the canonical files in the repository on every build, so they always reflect the latest standards.
+
+- <a href="/downloads/AGENTS.md" download="AGENTS.md"><code>AGENTS.md</code></a> — canonical source (all tools)
+- <a href="/downloads/CLAUDE.md" download="CLAUDE.md"><code>CLAUDE.md</code></a> — Claude Code
+- <a href="/downloads/think-standards.mdc" download="think-standards.mdc"><code>.cursor/rules/think-standards.mdc</code></a> — Cursor
+- <a href="/downloads/copilot-instructions.md" download="copilot-instructions.md"><code>.github/copilot-instructions.md</code></a> — GitHub Copilot
 
 ## Per-Tool Setup
 

--- a/content/ai/index.mdx
+++ b/content/ai/index.mdx
@@ -1,0 +1,77 @@
+---
+title: AI-Assisted Coding
+date: "2026-05-21T00:00:00.000Z"
+area: AI
+section: 1. Overview
+description: "How Think Company uses AI coding assistants and the shared instruction files that keep them aligned with our standards."
+---
+
+This document covers how we work with AI coding assistants at Think Company and the shared instruction files that point those tools at the standards in this site.
+
+## Table of Contents
+
+- [Why Standardized AI Files](#why-standardized-ai-files)
+- [The Files](#the-files)
+- [Per-Tool Setup](#per-tool-setup)
+- [Keeping Them in Sync](#keeping-them-in-sync)
+- [What's Inside](#whats-inside)
+- [Contributing](#contributing)
+
+## Why Standardized AI Files
+
+Most of our developers use an AI coding assistant — Claude Code, Cursor, GitHub Copilot, or more than one. Each tool reads project-level instructions from a different file in a different location, but the *guidance* should be identical no matter which tool a developer reaches for.
+
+We maintain one canonical source of truth and generate the per-tool files from it. This means:
+
+- The same standards apply whether code is written by a person or suggested by an assistant.
+- A developer switching tools (or a project using several) gets consistent results.
+- Updates to our standards flow to every assistant through one reviewed change.
+
+These instruction files encode the same standards published on this site — they are a machine-readable companion to the human-readable guidelines, not a separate ruleset.
+
+## The Files
+
+All four files live at the **root of each project repository**:
+
+| File | Tool | Role |
+| --- | --- | --- |
+| `AGENTS.md` | All / canonical | The source of truth. Human-readable, tool-agnostic. Edit this first. |
+| `CLAUDE.md` | Claude Code | Full copy of `AGENTS.md` plus a short Claude-specific behavior section. |
+| `.cursor/rules/think-standards.mdc` | Cursor | A scoped rule file (glob-targeted) summarizing the key rules. |
+| `.github/copilot-instructions.md` | GitHub Copilot | A condensed summary tuned for inline suggestions. |
+
+`AGENTS.md` is the authoritative document. `CLAUDE.md` is a complete embed of it (tools don't reliably follow file references, so it is duplicated rather than linked). The Cursor and Copilot files are intentional summaries.
+
+## Per-Tool Setup
+
+**Claude Code** — Place `CLAUDE.md` in the repo root; it is read automatically every session. For a personal default across all projects, copy it to `~/.claude/CLAUDE.md` (project-level files take precedence).
+
+**Cursor** — Place `think-standards.mdc` in `.cursor/rules/`. Its `alwaysApply: true` frontmatter and glob targets load it automatically for matching files.
+
+**GitHub Copilot** — Place `copilot-instructions.md` in `.github/`. Copilot reads it automatically in VS Code (v1.99+) and on GitHub.com.
+
+## Keeping Them in Sync
+
+When standards change, edit `AGENTS.md` first, then regenerate the others:
+
+- **`CLAUDE.md`** = the full contents of `AGENTS.md` plus the Claude-specific behavior section appended at the end. Re-copy on every change.
+- **`.cursor/rules/think-standards.mdc`** and **`.github/copilot-instructions.md`** are summaries — update them only when a major section is added, removed, or reversed.
+
+Treat the instruction files like any other code: changes go through a pull request so the team can review them.
+
+## What's Inside
+
+The instruction files mirror the standards published across this site. Each maps to a section here:
+
+- [HTML](/html/programming-principles/) — semantic markup, attribute order, forms
+- [CSS](/css/) — vanilla CSS and Tailwind, SMACSS architecture, modern CSS features
+- [Javascript](/javascript/) — modern JS and TypeScript authoring
+- [React](/javascript/react-best-practices/) — components, hooks, state, effects
+- [Accessibility](/accessibility/) — WCAG 2.2 AA
+- [Performance](/performance/) — Core Web Vitals
+- [Quality Assurance](/quality-assurance/) — linting, type-checking, security
+- [Git](/git/) — branches, commits, pull requests
+
+## Contributing
+
+The canonical files live in the [think_dev-standards](https://github.com/thinkcompany/think_dev-standards) repository. To propose a change, open a pull request against `AGENTS.md` (and regenerate the per-tool files), or [open an issue](https://github.com/thinkcompany/think_dev-standards/issues) describing the change you'd like to see. As with all of our standards: if you can't meet a guideline, or you see a better practice worth adopting, say so.

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -6,6 +6,23 @@ exports.createPages = async ({ graphql, actions }) => {
   const result = await graphql(
     `
       {
+        ai: allMdx(filter: { frontmatter: { area: { eq: "AI" } } }) {
+          edges {
+            node {
+              excerpt
+              fields {
+                slug
+              }
+              frontmatter {
+                date(formatString: "MMMM DD, YYYY")
+                title
+                section
+                description
+                area
+              }
+            }
+          }
+        }
         accessibility: allMdx(
           filter: { frontmatter: { area: { eq: "Accessibility" } } }
         ) {
@@ -196,6 +213,7 @@ exports.createPages = async ({ graphql, actions }) => {
 
   //This section loops through all the markdown data for each category of content.
   //It creates pages for that content using the landing.js template
+  const aiPosts = result.data.ai.edges;
   const accessibilityPosts = result.data.accessibility.edges;
   const automatedTestingPosts = result.data.automatedtesting.edges;
   const cssPosts = result.data.css.edges;
@@ -207,6 +225,19 @@ exports.createPages = async ({ graphql, actions }) => {
   const sassPosts = result.data.sass.edges;
   const seoPosts = result.data.seo.edges;
   const landingPage = path.resolve(`./src/templates/landing.js`);
+
+  //AI content
+  aiPosts.forEach((post) => {
+    createPage({
+      path: post.node.fields.slug,
+      component: landingPage,
+      context: {
+        slug: post.node.fields.slug,
+        area: "AI",
+        title: "AI-Assisted Coding",
+      },
+    });
+  });
 
   //Accessibility content
   accessibilityPosts.forEach((post) => {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,10 @@
     "url": "git+https://github.com/gatsbyjs/gatsby-starter-blog.git"
   },
   "scripts": {
+    "copy:ai-files": "node scripts/copy-ai-files.js",
+    "prebuild": "npm run copy:ai-files",
     "build": "gatsby build",
+    "predevelop": "npm run copy:ai-files",
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "start": "npm run develop",

--- a/scripts/copy-ai-files.js
+++ b/scripts/copy-ai-files.js
@@ -1,0 +1,30 @@
+// Copies the canonical AI agent instruction files (which live at the repo root)
+// into static/downloads/ so the site can serve them as downloadable files on the
+// /ai/ page. Run automatically before `build` and `develop` via npm pre-scripts,
+// so the downloads never drift from the source files.
+
+const fs = require("fs");
+const path = require("path");
+
+const root = path.resolve(__dirname, "..");
+const destDir = path.join(root, "static", "downloads");
+
+const files = [
+  { src: "AGENTS.md", dest: "AGENTS.md" },
+  { src: "CLAUDE.md", dest: "CLAUDE.md" },
+  { src: path.join(".cursor", "rules", "think-standards.mdc"), dest: "think-standards.mdc" },
+  { src: path.join(".github", "copilot-instructions.md"), dest: "copilot-instructions.md" },
+];
+
+fs.mkdirSync(destDir, { recursive: true });
+
+for (const { src, dest } of files) {
+  const from = path.join(root, src);
+  const to = path.join(destDir, dest);
+  if (!fs.existsSync(from)) {
+    console.warn(`copy-ai-files: source not found, skipping: ${src}`);
+    continue;
+  }
+  fs.copyFileSync(from, to);
+  console.log(`copy-ai-files: ${src} -> static/downloads/${dest}`);
+}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -16,6 +16,29 @@ const HomePage = () => {
         overlayOpacity="0"
       ></HeroBlock>
       <div className={styles.NavGrid}>
+        <Link to="/ai/" className={styles.linkCard}>
+          <div className={styles.LandingPageCard}>
+            <div className={styles.iconContainer}>
+              <svg
+                aria-hidden="true"
+                focusable="false"
+                data-prefix="fas"
+                data-icon="robot"
+                className={styles.icon}
+                role="img"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 640 512"
+              >
+                <path
+                  fill="currentColor"
+                  d="M32,224H64V416H32A31.96166,31.96166,0,0,1,0,384V256A31.96166,31.96166,0,0,1,32,224Zm512-48V448a64.06328,64.06328,0,0,1-64,64H160a64.06328,64.06328,0,0,1-64-64V176a79.974,79.974,0,0,1,80-80H288V32a32,32,0,0,1,64,0V96H464A79.974,79.974,0,0,1,544,176ZM264,256a40,40,0,1,0-40,40A39.997,39.997,0,0,0,264,256Zm-8,128H192v32h64Zm96,0H288v32h64ZM456,256a40,40,0,1,0-40,40A39.997,39.997,0,0,0,456,256Zm-8,128H384v32h64ZM640,256V384a31.96166,31.96166,0,0,1-32,32H576V224h32A31.96166,31.96166,0,0,1,640,256Z"
+                ></path>
+              </svg>
+            </div>
+            <h3>AI-Assisted Coding</h3>
+            <p>Shared agent files and how we work with AI</p>
+          </div>
+        </Link>
         <Link to="/accessibility/" className={styles.linkCard}>
           <div className={styles.LandingPageCard}>
             <div className={styles.iconContainer}>

--- a/static/downloads/AGENTS.md
+++ b/static/downloads/AGENTS.md
@@ -42,7 +42,7 @@ These instructions apply to all AI-assisted coding at Think Company. They encode
 - Use ES modules (`import`/`export`). Prefer named exports over default exports for non-component modules.
 - Use the modern operators: optional chaining (`?.`), nullish coalescing (`??`), and logical assignment (`??=`, `||=`, `&&=`). Use `??` (not `||`) for defaults so `0` and `''` are preserved.
 - Use `async`/`await` over hand-rolled promise chains. Run independent async work concurrently with `Promise.all`; use `Promise.allSettled` when failures should not short-circuit. Sequential `await`s on independent calls are a performance bug.
-- Iterate with `for...of` and array methods. Never use `for...in`; use `Object.keys`/`Object.values`/`Object.entries` for objects.
+- Prefer functional array methods (`.map`, `.filter`, `.reduce`, `.some`, `.every`) for data transformation and side-effect-free logic. Use `for...of` for sequential asynchronous tasks or when early break/continue is necessary. Never use `for...in`; use `Object.keys`/`Object.values`/`Object.entries` for objects.
 - Bind events with `addEventListener` — never inline `on*` attributes. Use `IntersectionObserver`/`ResizeObserver` instead of polling `scroll`/`resize`; debounce or throttle high-frequency handlers.
 - Use trailing commas in multi-line objects, arrays, and parameter lists.
 - When converting strings to numbers, use `Number()` or `Number.parseInt(value, 10)` with an explicit radix.

--- a/static/downloads/AGENTS.md
+++ b/static/downloads/AGENTS.md
@@ -1,0 +1,226 @@
+# Think Company — AI Agent Coding Instructions
+
+These instructions apply to all AI-assisted coding at Think Company. They encode our front-end development standards and are the authoritative source for the per-tool files (`CLAUDE.md`, `.cursor/rules/`, `.github/copilot-instructions.md`).
+
+---
+
+## Core Principles
+
+- Write code that is readable, modular, and accessible by default.
+- Prefer explicit over clever. Prioritize the next developer's ability to understand and change the code.
+- Follow the conventions already in use in the project. When in doubt, match the surrounding code.
+- Do not add features, abstractions, or error handling beyond what the task requires.
+- Validate at system boundaries (user input, external APIs). Trust internal code.
+
+---
+
+## TypeScript
+
+- All new code must be TypeScript. Do not introduce plain `.js` files.
+- Enable `strict: true` in `tsconfig.json`. Never disable strict mode to work around a type error — fix the type.
+- Never use `any`. Prefer `unknown` when the type is genuinely unknown and narrow it explicitly.
+- Prefer `interface` for object shapes that may be extended; use `type` for unions, intersections, and aliases.
+- Use built-in utility types (`Partial`, `Required`, `Pick`, `Omit`, `Readonly`, `ReturnType`, etc.) rather than re-implementing them.
+- Keep type definitions co-located with the code that uses them. Only promote to a shared `types/` directory when truly shared.
+- Avoid type assertions (`as Foo`) except at verified system boundaries. Never use non-null assertions (`!`) without a comment explaining why the value cannot be null.
+- Prefer `satisfies` over `as` when you need to validate a value against a type without widening it.
+- Use `as const` to lock object and tuple literals to their narrowest types (e.g. to derive a union from an array of values).
+- Model mutually-exclusive states as discriminated unions (a shared literal `kind`/`status` tag), not a bag of optional fields. Narrow them with `switch`.
+- For data crossing a system boundary (API responses, form input, `localStorage`), type it as `unknown` and validate at runtime with a schema validator (Zod or Valibot) before use. Do not trust a hand-written `as` cast on external data.
+- Enable `noUncheckedIndexedAccess` so indexed access (`arr[i]`, `record[key]`) is typed as possibly `undefined`. Consider `exactOptionalPropertyTypes` per project — it is stricter and can fight library interop.
+
+---
+
+## JavaScript
+
+- Use `const` by default. Use `let` only when the value will be reassigned. Never use `var`.
+- Declare variables close to where they are first used, not in a block at the top of the scope.
+- Use `===` and `!==`. Never `==` or `!=`.
+- Be explicit in conditions when the type is ambiguous. Truthy shortcuts hide bugs around `0`, `''`, and `null` — prefer `if (count > 0)` over `if (count)` and `if (name != null)` over `if (name)`.
+- Use template literals for string interpolation. No string concatenation.
+- Arrow functions for callbacks and closures. Named function declarations for top-level functions (better stack traces).
+- Use ES modules (`import`/`export`). Prefer named exports over default exports for non-component modules.
+- Use the modern operators: optional chaining (`?.`), nullish coalescing (`??`), and logical assignment (`??=`, `||=`, `&&=`). Use `??` (not `||`) for defaults so `0` and `''` are preserved.
+- Use `async`/`await` over hand-rolled promise chains. Run independent async work concurrently with `Promise.all`; use `Promise.allSettled` when failures should not short-circuit. Sequential `await`s on independent calls are a performance bug.
+- Iterate with `for...of` and array methods. Never use `for...in`; use `Object.keys`/`Object.values`/`Object.entries` for objects.
+- Bind events with `addEventListener` — never inline `on*` attributes. Use `IntersectionObserver`/`ResizeObserver` instead of polling `scroll`/`resize`; debounce or throttle high-frequency handlers.
+- Use trailing commas in multi-line objects, arrays, and parameter lists.
+- When converting strings to numbers, use `Number()` or `Number.parseInt(value, 10)` with an explicit radix.
+- Never use `eval` or the `Function` constructor.
+- Avoid assignments inside conditionals.
+
+---
+
+## React
+
+- Use functional components exclusively. Do not write new class components.
+- Use hooks for all state and side effects. Do not use `componentWillMount`, `componentWillReceiveProps`, or other deprecated lifecycle methods.
+- One component per file. Filename and component name must match. Use PascalCase (e.g., `UserCard.tsx`).
+- Always use `.tsx` for files containing JSX.
+- Use double quotes for JSX attributes; single quotes for all other JS/TS strings.
+- Do not use array index as `key` prop. Use a stable, unique ID.
+- Do not spread props onto DOM elements without filtering (`{...rest}` onto a `<div>` leaks unknown attributes).
+- State management — match the tool to the *kind* of state:
+  - Local component state: `useState` (or `useReducer` for complex transitions).
+  - Shared across a small subtree: React Context. Do not reach for a global store just to avoid prop drilling.
+  - Server state (API data, caching, revalidation): TanStack Query or SWR. Do not put server data in Redux.
+  - URL state (filters, pagination): keep it in query params via the router.
+  - Global client state: Zustand or Jotai for lighter needs; Redux Toolkit (RTK) on larger projects.
+- `useEffect` is for synchronizing with external systems, not for deriving data. Compute derived values during render — do not mirror props into state via an effect. Declare every reactive dependency (do not disable `react-hooks/exhaustive-deps`), and return a cleanup function for subscriptions, timers, and connections.
+- Extract reusable stateful logic into custom hooks (`use`-prefixed), not HOCs or render props.
+- Wrap failure-prone subtrees (data fetching, third-party widgets, route components) in an error boundary.
+- In React 19 / Next.js App Router, components are Server Components by default. Mark components that use state, effects, or browser APIs with `'use client'`, and push client components as far down the tree as possible.
+- Do not use `isMounted`. It is deprecated and unavailable in functional components.
+- Conditional rendering: avoid nested ternaries. Break complex conditionals into separate components.
+- PropTypes are not required in TypeScript projects — use TypeScript types instead.
+
+---
+
+## CSS
+
+- Author **vanilla CSS** on all projects. Use **Tailwind CSS** as a utility layer where the project and client permit. Sass/SCSS is no longer the default — projects already on Sass may continue, but do not start new work in it.
+- Use CSS custom properties for all design tokens (colors, spacing, type scale, z-index, breakpoints). Define them on `:root`.
+- Do not use vendor mixin libraries. Avoid manual vendor prefixes — use Autoprefixer in the build pipeline.
+- Architecture follows SMACSS: Settings → Base → Layout → Modules → Helpers.
+  - State classes: prefix with `is-` or `has-`.
+  - Subcomponents: `[module]-[subcomponent]`.
+  - Modifiers: `[module]--[modifier]`.
+- Name selectors based on function, not appearance. Lowercase, hyphen-separated.
+- Do not use IDs as styling hooks. Use class names.
+- Keep specificity low. Author from general to specific.
+- Nest no more than 3 levels deep (including pseudo-classes and pseudo-elements).
+- Do not use `!important` except to override unmodifiable third-party styles (add a comment explaining why).
+- Use `box-sizing: border-box` globally via the inherit pattern.
+- Use relative units (`em`, `rem`, `%`) over `px` wherever possible.
+- Do not use `line-height` with a unit. Use a unitless ratio (e.g., `line-height: 1.5`).
+- Declaration order within a rule: custom properties → layout → box model → typography → visual → interaction → animation.
+- Name and place media queries alongside their base ruleset, smallest to largest (mobile-first).
+
+### File naming convention
+
+`[category].[partial-name].css`
+
+Examples: `settings.tokens.css`, `layout.grid.css`, `module.card.css`, `helpers.spacing.css`
+
+### Tailwind
+
+- Use Tailwind only where the team has agreed and no conflicting CSS architecture exists.
+- Order utility classes layout → box model → typography → visual → interaction → animation; enforce with the Prettier Tailwind plugin.
+- Prefer extracting a reusable component over `@apply`. Use `@apply` only where JSX components aren't available (e.g. CMS templates).
+- Map tokens in config to custom properties; don't use arbitrary values (`w-[347px]`) for things that should be tokens.
+
+### Modern CSS features
+
+These have reached broad/Baseline support — treat them as first-class tools, not experimental:
+
+- **Cascade layers (`@layer`)** to manage specificity across resets, third-party styles, and your own code without `!important`.
+- **Container queries** when a component's layout depends on its container's size rather than the viewport.
+- **`:has()`** to style a parent based on its descendants — replaces many JS class-toggling patterns.
+- **Logical properties** (`margin-inline`, `padding-block`, `border-inline-start`) over physical ones for RTL-friendly layouts.
+- **Modern color** — `oklch()` for perceptually-uniform colors, `color-mix()` to derive related colors from a token.
+- **Custom properties** for all design tokens (colors, spacing, type scale, z-index).
+
+---
+
+## HTML
+
+- All HTML must conform to the HTML5 spec. Validate with the W3C validator.
+- Write semantic markup. Use the correct element for the meaning, not for the appearance.
+- Use HTML5 sectioning elements (`<header>`, `<main>`, `<article>`, `<aside>`, `<nav>`, `<footer>`).
+- All elements and attribute names must be lowercase. Attribute values in double quotes. Void elements (`<img>`, `<input>`, `<br>`, etc.) do not need a trailing slash — that's an XHTML convention.
+- Attribute order: `class` → `id`/`name` → `data-*` → `src`/`for`/`type`/`href`/`value` → `title`/`alt` → `aria-*`/`role`.
+- Use `<button>` for actions, `<a>` for navigation. Use `type="button"` on `<button>` elements outside of forms.
+- Never use inline styles or inline event handlers. Hook JavaScript behavior via `data-*` attributes.
+- Use `<label>` for every form field, explicitly associated via `for`/`id`.
+- Do not use presentational elements (`<font>`, `<center>`, etc.) or attributes (`align`, `valign`).
+- Do not set `maximum-scale` or `user-scalable=no` in the viewport meta tag.
+
+---
+
+## Accessibility
+
+Target WCAG 2.2 Level AA compliance on all projects.
+
+- Always declare the page language: `<html lang="en">`.
+- Heading hierarchy must be logical and sequential. One `<h1>` per page. Do not choose heading levels based on visual size.
+- Text contrast: 4.5:1 minimum for normal text; 3:1 for large or bold text.
+- Every interactive element must be keyboard-accessible. Never remove the default focus outline without replacing it with a clearly visible alternative. Prefer `:focus-visible` over `:focus` so mouse clicks don't show a stray ring. Focus indicators need at least a 2px outline at 3:1 contrast (WCAG 2.2 SC 2.4.11/2.4.13).
+- Interactive targets must be at least 24×24 CSS pixels (WCAG 2.2 SC 2.5.8); 44×44 is the AAA/design-system target.
+- Wrap non-essential animation in `@media (prefers-reduced-motion: reduce)` and disable it there.
+- Provide a visually-hidden "Skip to main content" link as the first focusable element on each page.
+- Use ARIA attributes only when native HTML semantics are insufficient. Incorrect ARIA is worse than no ARIA.
+- Use `aria-haspopup`, `aria-expanded`, and `aria-hidden` to communicate toggle state.
+- Bind keyboard events (`focus`, `keydown`) alongside mouse events. Do not rely on hover-only interactions.
+- All `<img>` elements must have an `alt` attribute. Decorative images use `alt=""`.
+- Do not use color alone to convey information.
+- Error validation fires on submit, not on keystroke or blur. On error: move focus to the first invalid field, set `aria-invalid="true"`, link to the error message via `aria-describedby`.
+- Use the native HTML `required` attribute as the source of truth for required fields — it is well-supported by current screen readers and gives free browser validation. `aria-required="true"` is redundant when `required` is present; use it only on custom widgets that can't use the native attribute.
+- Test with: VoiceOver (macOS/iOS), NVDA + Firefox (Windows), TalkBack (Android). Use the axe browser extension for automated checks.
+
+---
+
+## Git
+
+### Branches
+
+- Branch names: `feature/TICKET-000-short-description` or `fix/TICKET-000-short-description`.
+- Use hyphens to separate words. Keep names short and descriptive.
+- Delete branches after merging.
+
+### Commits
+
+- Each commit = one logical change. Do not combine unrelated changes.
+- Commit early and often. Small, self-contained commits are easier to revert.
+- Use [Conventional Commits](https://www.conventionalcommits.org/) format:
+  ```
+  feat(scope): add user avatar upload
+  fix(auth): handle expired token on refresh
+  ```
+- Reference ticket IDs in the commit body when relevant.
+- Do not push half-done work. Use `git stash` instead.
+
+### Merging
+
+- Rebase personal branches onto the target branch before merging to keep history linear.
+- Use `--no-ff` when merging a branch with multiple commits.
+- Never force-push to a shared branch unless the entire team is aware and coordinated.
+- Never rewrite history on `main` or any production/CI branch.
+
+### Pull Requests
+
+Every PR must include:
+
+- **Summary** — what changed and why
+- **Testing instructions** — how to verify the change
+- **Ticket link(s)**
+- **Screenshots or recordings** for any UI/UX changes
+- **Checklist** confirming tests pass, linting is clean, and accessibility was considered
+
+Use CI/CD to run linting, type checks, and tests automatically on every PR. Do not merge a PR with failing checks.
+
+---
+
+## Security
+
+- Never commit secrets, API keys, credentials, or `.env` files. Use environment variables and a secrets manager. Run a secret-scanning hook (e.g. gitleaks). If a secret reaches version control, rotate it first, then scrub history.
+- Validate and sanitize all user input at the boundary. Do not trust client-supplied data server-side. Never build SQL or shell commands via string concatenation — use parameterized queries.
+- Follow OWASP Top 10 guidance. Pay particular attention to XSS, CSRF, injection, and supply-chain attacks.
+- Set a Content Security Policy (CSP) — prefer nonce/hash allowlisting over `'unsafe-inline'`. It is one of the highest-leverage XSS defenses.
+- Add Subresource Integrity (`integrity="sha384-…"`) to third-party scripts loaded from a CDN you don't control.
+- Serve over HTTPS and send `Strict-Transport-Security` (HSTS).
+- Automate dependency scanning (Dependabot or Renovate, plus `npm audit`/Snyk in CI). Review lockfile changes carefully — pin versions.
+- Set least-privilege access for all roles, service accounts, and CI tokens.
+- Remove unused code, dependencies, and assets before shipping.
+- Strip metadata from SVGs before committing. Any process accepting user-uploaded SVGs must sanitize embedded `<script>` and event-handler attributes.
+
+---
+
+## Code Review Expectations
+
+When reviewing or generating code for PR review:
+
+- Check for logic errors, edge cases, and unhandled states.
+- Flag any use of `any`, non-null assertions, or type assertions without comments.
+- Confirm accessibility requirements are met for any UI changes.
+- Confirm no secrets or credentials are present.
+- Confirm the PR description matches the diff.

--- a/static/downloads/CLAUDE.md
+++ b/static/downloads/CLAUDE.md
@@ -1,0 +1,237 @@
+# Think Company — AI Agent Coding Instructions
+
+These instructions apply to all AI-assisted coding at Think Company. They encode our front-end development standards and are the authoritative source for the per-tool files (`CLAUDE.md`, `.cursor/rules/`, `.github/copilot-instructions.md`).
+
+---
+
+## Core Principles
+
+- Write code that is readable, modular, and accessible by default.
+- Prefer explicit over clever. Prioritize the next developer's ability to understand and change the code.
+- Follow the conventions already in use in the project. When in doubt, match the surrounding code.
+- Do not add features, abstractions, or error handling beyond what the task requires.
+- Validate at system boundaries (user input, external APIs). Trust internal code.
+
+---
+
+## TypeScript
+
+- All new code must be TypeScript. Do not introduce plain `.js` files.
+- Enable `strict: true` in `tsconfig.json`. Never disable strict mode to work around a type error — fix the type.
+- Never use `any`. Prefer `unknown` when the type is genuinely unknown and narrow it explicitly.
+- Prefer `interface` for object shapes that may be extended; use `type` for unions, intersections, and aliases.
+- Use built-in utility types (`Partial`, `Required`, `Pick`, `Omit`, `Readonly`, `ReturnType`, etc.) rather than re-implementing them.
+- Keep type definitions co-located with the code that uses them. Only promote to a shared `types/` directory when truly shared.
+- Avoid type assertions (`as Foo`) except at verified system boundaries. Never use non-null assertions (`!`) without a comment explaining why the value cannot be null.
+- Prefer `satisfies` over `as` when you need to validate a value against a type without widening it.
+- Use `as const` to lock object and tuple literals to their narrowest types (e.g. to derive a union from an array of values).
+- Model mutually-exclusive states as discriminated unions (a shared literal `kind`/`status` tag), not a bag of optional fields. Narrow them with `switch`.
+- For data crossing a system boundary (API responses, form input, `localStorage`), type it as `unknown` and validate at runtime with a schema validator (Zod or Valibot) before use. Do not trust a hand-written `as` cast on external data.
+- Enable `noUncheckedIndexedAccess` so indexed access (`arr[i]`, `record[key]`) is typed as possibly `undefined`. Consider `exactOptionalPropertyTypes` per project — it is stricter and can fight library interop.
+
+---
+
+## JavaScript
+
+- Use `const` by default. Use `let` only when the value will be reassigned. Never use `var`.
+- Declare variables close to where they are first used, not in a block at the top of the scope.
+- Use `===` and `!==`. Never `==` or `!=`.
+- Be explicit in conditions when the type is ambiguous. Truthy shortcuts hide bugs around `0`, `''`, and `null` — prefer `if (count > 0)` over `if (count)` and `if (name != null)` over `if (name)`.
+- Use template literals for string interpolation. No string concatenation.
+- Arrow functions for callbacks and closures. Named function declarations for top-level functions (better stack traces).
+- Use ES modules (`import`/`export`). Prefer named exports over default exports for non-component modules.
+- Use the modern operators: optional chaining (`?.`), nullish coalescing (`??`), and logical assignment (`??=`, `||=`, `&&=`). Use `??` (not `||`) for defaults so `0` and `''` are preserved.
+- Use `async`/`await` over hand-rolled promise chains. Run independent async work concurrently with `Promise.all`; use `Promise.allSettled` when failures should not short-circuit. Sequential `await`s on independent calls are a performance bug.
+- Iterate with `for...of` and array methods. Never use `for...in`; use `Object.keys`/`Object.values`/`Object.entries` for objects.
+- Bind events with `addEventListener` — never inline `on*` attributes. Use `IntersectionObserver`/`ResizeObserver` instead of polling `scroll`/`resize`; debounce or throttle high-frequency handlers.
+- Use trailing commas in multi-line objects, arrays, and parameter lists.
+- When converting strings to numbers, use `Number()` or `Number.parseInt(value, 10)` with an explicit radix.
+- Never use `eval` or the `Function` constructor.
+- Avoid assignments inside conditionals.
+
+---
+
+## React
+
+- Use functional components exclusively. Do not write new class components.
+- Use hooks for all state and side effects. Do not use `componentWillMount`, `componentWillReceiveProps`, or other deprecated lifecycle methods.
+- One component per file. Filename and component name must match. Use PascalCase (e.g., `UserCard.tsx`).
+- Always use `.tsx` for files containing JSX.
+- Use double quotes for JSX attributes; single quotes for all other JS/TS strings.
+- Do not use array index as `key` prop. Use a stable, unique ID.
+- Do not spread props onto DOM elements without filtering (`{...rest}` onto a `<div>` leaks unknown attributes).
+- State management — match the tool to the *kind* of state:
+  - Local component state: `useState` (or `useReducer` for complex transitions).
+  - Shared across a small subtree: React Context. Do not reach for a global store just to avoid prop drilling.
+  - Server state (API data, caching, revalidation): TanStack Query or SWR. Do not put server data in Redux.
+  - URL state (filters, pagination): keep it in query params via the router.
+  - Global client state: Zustand or Jotai for lighter needs; Redux Toolkit (RTK) on larger projects.
+- `useEffect` is for synchronizing with external systems, not for deriving data. Compute derived values during render — do not mirror props into state via an effect. Declare every reactive dependency (do not disable `react-hooks/exhaustive-deps`), and return a cleanup function for subscriptions, timers, and connections.
+- Extract reusable stateful logic into custom hooks (`use`-prefixed), not HOCs or render props.
+- Wrap failure-prone subtrees (data fetching, third-party widgets, route components) in an error boundary.
+- In React 19 / Next.js App Router, components are Server Components by default. Mark components that use state, effects, or browser APIs with `'use client'`, and push client components as far down the tree as possible.
+- Do not use `isMounted`. It is deprecated and unavailable in functional components.
+- Conditional rendering: avoid nested ternaries. Break complex conditionals into separate components.
+- PropTypes are not required in TypeScript projects — use TypeScript types instead.
+
+---
+
+## CSS
+
+- Author **vanilla CSS** on all projects. Use **Tailwind CSS** as a utility layer where the project and client permit. Sass/SCSS is no longer the default — projects already on Sass may continue, but do not start new work in it.
+- Use CSS custom properties for all design tokens (colors, spacing, type scale, z-index, breakpoints). Define them on `:root`.
+- Do not use vendor mixin libraries. Avoid manual vendor prefixes — use Autoprefixer in the build pipeline.
+- Architecture follows SMACSS: Settings → Base → Layout → Modules → Helpers.
+  - State classes: prefix with `is-` or `has-`.
+  - Subcomponents: `[module]-[subcomponent]`.
+  - Modifiers: `[module]--[modifier]`.
+- Name selectors based on function, not appearance. Lowercase, hyphen-separated.
+- Do not use IDs as styling hooks. Use class names.
+- Keep specificity low. Author from general to specific.
+- Nest no more than 3 levels deep (including pseudo-classes and pseudo-elements).
+- Do not use `!important` except to override unmodifiable third-party styles (add a comment explaining why).
+- Use `box-sizing: border-box` globally via the inherit pattern.
+- Use relative units (`em`, `rem`, `%`) over `px` wherever possible.
+- Do not use `line-height` with a unit. Use a unitless ratio (e.g., `line-height: 1.5`).
+- Declaration order within a rule: custom properties → layout → box model → typography → visual → interaction → animation.
+- Name and place media queries alongside their base ruleset, smallest to largest (mobile-first).
+
+### File naming convention
+
+`[category].[partial-name].css`
+
+Examples: `settings.tokens.css`, `layout.grid.css`, `module.card.css`, `helpers.spacing.css`
+
+### Tailwind
+
+- Use Tailwind only where the team has agreed and no conflicting CSS architecture exists.
+- Order utility classes layout → box model → typography → visual → interaction → animation; enforce with the Prettier Tailwind plugin.
+- Prefer extracting a reusable component over `@apply`. Use `@apply` only where JSX components aren't available (e.g. CMS templates).
+- Map tokens in config to custom properties; don't use arbitrary values (`w-[347px]`) for things that should be tokens.
+
+### Modern CSS features
+
+These have reached broad/Baseline support — treat them as first-class tools, not experimental:
+
+- **Cascade layers (`@layer`)** to manage specificity across resets, third-party styles, and your own code without `!important`.
+- **Container queries** when a component's layout depends on its container's size rather than the viewport.
+- **`:has()`** to style a parent based on its descendants — replaces many JS class-toggling patterns.
+- **Logical properties** (`margin-inline`, `padding-block`, `border-inline-start`) over physical ones for RTL-friendly layouts.
+- **Modern color** — `oklch()` for perceptually-uniform colors, `color-mix()` to derive related colors from a token.
+- **Custom properties** for all design tokens (colors, spacing, type scale, z-index).
+
+---
+
+## HTML
+
+- All HTML must conform to the HTML5 spec. Validate with the W3C validator.
+- Write semantic markup. Use the correct element for the meaning, not for the appearance.
+- Use HTML5 sectioning elements (`<header>`, `<main>`, `<article>`, `<aside>`, `<nav>`, `<footer>`).
+- All elements and attribute names must be lowercase. Attribute values in double quotes. Void elements (`<img>`, `<input>`, `<br>`, etc.) do not need a trailing slash — that's an XHTML convention.
+- Attribute order: `class` → `id`/`name` → `data-*` → `src`/`for`/`type`/`href`/`value` → `title`/`alt` → `aria-*`/`role`.
+- Use `<button>` for actions, `<a>` for navigation. Use `type="button"` on `<button>` elements outside of forms.
+- Never use inline styles or inline event handlers. Hook JavaScript behavior via `data-*` attributes.
+- Use `<label>` for every form field, explicitly associated via `for`/`id`.
+- Do not use presentational elements (`<font>`, `<center>`, etc.) or attributes (`align`, `valign`).
+- Do not set `maximum-scale` or `user-scalable=no` in the viewport meta tag.
+
+---
+
+## Accessibility
+
+Target WCAG 2.2 Level AA compliance on all projects.
+
+- Always declare the page language: `<html lang="en">`.
+- Heading hierarchy must be logical and sequential. One `<h1>` per page. Do not choose heading levels based on visual size.
+- Text contrast: 4.5:1 minimum for normal text; 3:1 for large or bold text.
+- Every interactive element must be keyboard-accessible. Never remove the default focus outline without replacing it with a clearly visible alternative. Prefer `:focus-visible` over `:focus` so mouse clicks don't show a stray ring. Focus indicators need at least a 2px outline at 3:1 contrast (WCAG 2.2 SC 2.4.11/2.4.13).
+- Interactive targets must be at least 24×24 CSS pixels (WCAG 2.2 SC 2.5.8); 44×44 is the AAA/design-system target.
+- Wrap non-essential animation in `@media (prefers-reduced-motion: reduce)` and disable it there.
+- Provide a visually-hidden "Skip to main content" link as the first focusable element on each page.
+- Use ARIA attributes only when native HTML semantics are insufficient. Incorrect ARIA is worse than no ARIA.
+- Use `aria-haspopup`, `aria-expanded`, and `aria-hidden` to communicate toggle state.
+- Bind keyboard events (`focus`, `keydown`) alongside mouse events. Do not rely on hover-only interactions.
+- All `<img>` elements must have an `alt` attribute. Decorative images use `alt=""`.
+- Do not use color alone to convey information.
+- Error validation fires on submit, not on keystroke or blur. On error: move focus to the first invalid field, set `aria-invalid="true"`, link to the error message via `aria-describedby`.
+- Use the native HTML `required` attribute as the source of truth for required fields — it is well-supported by current screen readers and gives free browser validation. `aria-required="true"` is redundant when `required` is present; use it only on custom widgets that can't use the native attribute.
+- Test with: VoiceOver (macOS/iOS), NVDA + Firefox (Windows), TalkBack (Android). Use the axe browser extension for automated checks.
+
+---
+
+## Git
+
+### Branches
+
+- Branch names: `feature/TICKET-000-short-description` or `fix/TICKET-000-short-description`.
+- Use hyphens to separate words. Keep names short and descriptive.
+- Delete branches after merging.
+
+### Commits
+
+- Each commit = one logical change. Do not combine unrelated changes.
+- Commit early and often. Small, self-contained commits are easier to revert.
+- Use [Conventional Commits](https://www.conventionalcommits.org/) format:
+  ```
+  feat(scope): add user avatar upload
+  fix(auth): handle expired token on refresh
+  ```
+- Reference ticket IDs in the commit body when relevant.
+- Do not push half-done work. Use `git stash` instead.
+
+### Merging
+
+- Rebase personal branches onto the target branch before merging to keep history linear.
+- Use `--no-ff` when merging a branch with multiple commits.
+- Never force-push to a shared branch unless the entire team is aware and coordinated.
+- Never rewrite history on `main` or any production/CI branch.
+
+### Pull Requests
+
+Every PR must include:
+
+- **Summary** — what changed and why
+- **Testing instructions** — how to verify the change
+- **Ticket link(s)**
+- **Screenshots or recordings** for any UI/UX changes
+- **Checklist** confirming tests pass, linting is clean, and accessibility was considered
+
+Use CI/CD to run linting, type checks, and tests automatically on every PR. Do not merge a PR with failing checks.
+
+---
+
+## Security
+
+- Never commit secrets, API keys, credentials, or `.env` files. Use environment variables and a secrets manager. Run a secret-scanning hook (e.g. gitleaks). If a secret reaches version control, rotate it first, then scrub history.
+- Validate and sanitize all user input at the boundary. Do not trust client-supplied data server-side. Never build SQL or shell commands via string concatenation — use parameterized queries.
+- Follow OWASP Top 10 guidance. Pay particular attention to XSS, CSRF, injection, and supply-chain attacks.
+- Set a Content Security Policy (CSP) — prefer nonce/hash allowlisting over `'unsafe-inline'`. It is one of the highest-leverage XSS defenses.
+- Add Subresource Integrity (`integrity="sha384-…"`) to third-party scripts loaded from a CDN you don't control.
+- Serve over HTTPS and send `Strict-Transport-Security` (HSTS).
+- Automate dependency scanning (Dependabot or Renovate, plus `npm audit`/Snyk in CI). Review lockfile changes carefully — pin versions.
+- Set least-privilege access for all roles, service accounts, and CI tokens.
+- Remove unused code, dependencies, and assets before shipping.
+- Strip metadata from SVGs before committing. Any process accepting user-uploaded SVGs must sanitize embedded `<script>` and event-handler attributes.
+
+---
+
+## Code Review Expectations
+
+When reviewing or generating code for PR review:
+
+- Check for logic errors, edge cases, and unhandled states.
+- Flag any use of `any`, non-null assertions, or type assertions without comments.
+- Confirm accessibility requirements are met for any UI changes.
+- Confirm no secrets or credentials are present.
+- Confirm the PR description matches the diff.
+
+---
+
+## Claude-specific behavior
+
+- Do not create planning or analysis documents unless explicitly asked. Work from conversation context.
+- Do not add comments explaining what the code does. Add a comment only when the WHY is non-obvious.
+- Do not summarize what you just did at the end of a response. The diff speaks for itself.
+- Default to editing existing files. Only create new files when the task requires it.
+- Do not add features, refactors, or abstractions beyond the stated task.
+- Run the type checker and linter before reporting a task complete.

--- a/static/downloads/copilot-instructions.md
+++ b/static/downloads/copilot-instructions.md
@@ -1,0 +1,50 @@
+# Think Company — GitHub Copilot Instructions
+
+Follow the standards in `AGENTS.md` at the repo root. The rules below are a summary for Copilot's inline suggestion context.
+
+## TypeScript
+- Strict mode. No `any`. Use `unknown` and narrow explicitly.
+- `interface` for extendable object shapes; `type` for unions and aliases.
+- Use utility types (`Partial`, `Pick`, `Omit`, `ReturnType`, etc.) — do not reimplement them.
+- Avoid `as` assertions and `!` non-null assertions without an explanatory comment.
+- Use `as const` and discriminated unions for state. Validate external data (API, form, storage) at runtime with Zod/Valibot, not an `as` cast.
+
+## JavaScript
+- `const` by default, never `var`. Declare variables near first use.
+- Be explicit in conditions: `if (count > 0)` over `if (count)` — truthy shortcuts hide `0`/`''`/`null` bugs.
+- Modern operators: `?.`, `??` (not `||`) for defaults, logical assignment.
+- `async`/`await` over promise chains; `Promise.all` for independent work.
+- `for...of` and `Object.entries` — never `for...in`. Trailing commas in multiline.
+- `addEventListener` only; `IntersectionObserver`/`ResizeObserver` over scroll/resize polling.
+
+## React
+- Functional components only. Hooks for state and effects.
+- One component per `.tsx` file. Filename = component name (PascalCase).
+- No array index as `key`. No spreading unknown props onto DOM elements.
+- `useEffect` synchronizes with external systems — don't derive state in it; declare all deps; return cleanup.
+- Server state → TanStack Query/SWR (not Redux). URL state → query params. Reusable logic → custom hooks.
+- Wrap failure-prone subtrees in an error boundary. Conditional rendering: no nested ternaries.
+
+## CSS
+- Vanilla CSS is the default; Tailwind as a utility layer where agreed. Sass is grandfathered, not for new work.
+- Custom properties for all design tokens. No vendor prefixes in source — use Autoprefixer.
+- No `!important`. No ID selectors for styling. Max 3 nesting levels.
+- Mobile-first media queries. Unitless `line-height`.
+- Modern CSS: cascade layers, container queries, `:has()`, logical properties, `oklch`/`color-mix`.
+
+## Accessibility
+- WCAG 2.2 AA. Keyboard-accessible. Visible focus states via `:focus-visible`.
+- Interactive targets ≥ 24×24px. Respect `prefers-reduced-motion`.
+- Semantic HTML. Logical heading hierarchy. `alt` on every `<img>`.
+- Native `required` is the source of truth for required fields; `aria-required` only on custom widgets.
+- ARIA only when native HTML is insufficient.
+
+## Git
+- Conventional Commits: `feat(scope): message` / `fix(scope): message`.
+- One logical change per commit.
+
+## General
+- No inline styles or inline event handlers.
+- No secrets or credentials in code; run a secret-scanning hook.
+- Validate input at system boundaries. Follow OWASP Top 10.
+- Set a CSP; add SRI to third-party scripts; enforce HTTPS/HSTS; automate dependency scanning.

--- a/static/downloads/copilot-instructions.md
+++ b/static/downloads/copilot-instructions.md
@@ -14,7 +14,7 @@ Follow the standards in `AGENTS.md` at the repo root. The rules below are a summ
 - Be explicit in conditions: `if (count > 0)` over `if (count)` — truthy shortcuts hide `0`/`''`/`null` bugs.
 - Modern operators: `?.`, `??` (not `||`) for defaults, logical assignment.
 - `async`/`await` over promise chains; `Promise.all` for independent work.
-- `for...of` and `Object.entries` — never `for...in`. Trailing commas in multiline.
+- Prefer functional array methods (`.map`, `.filter`, `.reduce`, `.some`, `.every`) for data transformation and side-effect-free logic. Use `for...of` for sequential asynchronous tasks or when early break/continue is necessary. `Object.entries` over `for...in`. Trailing commas in multiline.
 - `addEventListener` only; `IntersectionObserver`/`ResizeObserver` over scroll/resize polling.
 
 ## React

--- a/static/downloads/think-standards.mdc
+++ b/static/downloads/think-standards.mdc
@@ -11,7 +11,7 @@ Follow all standards in `AGENTS.md` at the repo root.
 ## Key rules for Cursor
 
 - TypeScript only. `strict: true`. Never use `any` — use `unknown` and narrow. Validate external data with Zod/Valibot, not an `as` cast.
-- `const` by default, never `var`. Modern operators (`?.`, `??`, logical assignment). `async`/`await` over promise chains. `for...of`/`Object.entries`, never `for...in`.
+- `const` by default, never `var`. Modern operators (`?.`, `??`, logical assignment). `async`/`await` over promise chains. Array methods (`.map`/`.filter`/`.reduce`/etc.) for transformations, `for...of`/`Object.entries` for imperative iteration — never `for...in`.
 - Functional React components only. Hooks for state and effects. `useEffect` synchronizes with external systems — don't derive state in it; declare all deps; return cleanup.
 - Server state → TanStack Query/SWR (not Redux). Reusable logic → custom hooks. Wrap failure-prone subtrees in an error boundary.
 - WCAG 2.2 AA accessibility on all UI. `:focus-visible` focus states, targets ≥ 24×24px, respect `prefers-reduced-motion`. Native `required` over `aria-required`.

--- a/static/downloads/think-standards.mdc
+++ b/static/downloads/think-standards.mdc
@@ -1,0 +1,23 @@
+---
+description: Think Company coding standards — applies to all files in this project
+globs: ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.scss", "**/*.css", "**/*.html"]
+alwaysApply: true
+---
+
+# Think Company Coding Standards
+
+Follow all standards in `AGENTS.md` at the repo root.
+
+## Key rules for Cursor
+
+- TypeScript only. `strict: true`. Never use `any` — use `unknown` and narrow. Validate external data with Zod/Valibot, not an `as` cast.
+- `const` by default, never `var`. Modern operators (`?.`, `??`, logical assignment). `async`/`await` over promise chains. `for...of`/`Object.entries`, never `for...in`.
+- Functional React components only. Hooks for state and effects. `useEffect` synchronizes with external systems — don't derive state in it; declare all deps; return cleanup.
+- Server state → TanStack Query/SWR (not Redux). Reusable logic → custom hooks. Wrap failure-prone subtrees in an error boundary.
+- WCAG 2.2 AA accessibility on all UI. `:focus-visible` focus states, targets ≥ 24×24px, respect `prefers-reduced-motion`. Native `required` over `aria-required`.
+- Vanilla CSS is the default; Tailwind as a utility layer where agreed. Sass is grandfathered, not for new work. Custom-property tokens; modern CSS (cascade layers, container queries, `:has()`, logical properties).
+- Conventional Commits format for commit messages.
+- No inline styles, no inline event handlers. No secrets in code.
+- One component per file, PascalCase filename matches component name.
+
+See `AGENTS.md` for the full standard.


### PR DESCRIPTION
## Summary

Adds a new **AI-Assisted Coding** section to the standards site, documenting how we work with AI coding assistants and the shared agent instruction files (`AGENTS.md`, `CLAUDE.md`, `.cursor/rules/`, `.github/copilot-instructions.md`) that were added in #21.

- New content page at `content/ai/index.mdx` (area `AI`, slug `/ai/`) covering: why we standardize AI files, the files and their roles, per-tool setup, how to keep them in sync, what's inside (cross-linked to existing standards), and how to contribute
- Wires the `AI` area into `gatsby-node.js` page generation, following the same pattern as every other area
- Adds an **AI-Assisted Coding** card to the homepage nav grid (robot icon)

## Test plan

- [ ] Netlify deploy preview builds successfully
- [ ] `/ai/` page renders with the side nav and content
- [ ] The new card appears on the homepage and links to `/ai/`
- [ ] Cross-links to other standards sections resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)